### PR TITLE
fix: stabilize API Hub authentication

### DIFF
--- a/packages/api-hub/src/api-hub-client.ts
+++ b/packages/api-hub/src/api-hub-client.ts
@@ -27,6 +27,16 @@ const CATEGORY_ROUTE_PREFIX: Record<string, string> = {
 export class SapApiHubClient {
   constructor(private config: ServerConfig) {}
 
+  async validateSession(cookie: string): Promise<boolean> {
+    try {
+      await this.getJson('/api/1.0/containergroup/ContentTypes?$expand=containers($expand=logo)', cookie);
+      return true;
+    } catch (error) {
+      logger.warn('API Hub session validation failed', error);
+      return false;
+    }
+  }
+
   async categories(cookie: string): Promise<{ categories: ApiHubCategory[]; raw: unknown }> {
     const raw = await this.getJson('/api/1.0/containergroup/ContentTypes?$expand=containers($expand=logo)', cookie);
     const containers = collectContainers(raw);

--- a/packages/api-hub/src/auth.ts
+++ b/packages/api-hub/src/auth.ts
@@ -1,6 +1,7 @@
 import { SapWebAuthenticator, type AuthConfig, type ServiceProfile } from '@marianfoo/sap-mcp-auth';
 import type { ServerConfig } from './types.js';
 import { logger } from './logger.js';
+import { SapApiHubClient } from './api-hub-client.js';
 
 /**
  * Build a SapWebAuthenticator configured for the SAP Business Accelerator Hub.
@@ -14,12 +15,15 @@ export function createApiHubAuthenticator(config: ServerConfig): SapWebAuthentic
     sapPassword: config.sapPassword,
     pfxPath: config.pfxPath,
     pfxPassphrase: config.pfxPassphrase,
-    sapLoginUrl: config.sapLoginUrl ?? 'https://me.sap.com/home',
+    // API Hub's OAuth flow can reject stale shared SSO/browser state with
+    // state_not_verified. Go directly to API Hub in a clean context and cache
+    // only the resulting api.sap.com cookies.
+    sapLoginUrl: undefined,
     mfaTimeout: config.mfaTimeout,
     maxSessionAgeH: config.maxCookieAgeH,
     headful: config.headful,
     tokenCacheFile: config.tokenCacheFile,
-    ssoStorageStateFile: config.ssoStorageStateFile,
+    ssoStorageStateFile: undefined,
     logger
   };
 
@@ -27,7 +31,8 @@ export function createApiHubAuthenticator(config: ServerConfig): SapWebAuthentic
     serviceName: 'SAP API Hub',
     appUrl: `${config.apiHubBaseUrl}/api/salesorder/overview`,
     cookieScope: { type: 'domain', includes: 'api.sap.com', fallbackToAll: true },
-    expectedHost: 'api.sap.com'
+    expectedHost: 'api.sap.com',
+    validateSession: cookieHeader => new SapApiHubClient(config).validateSession(cookieHeader)
   };
 
   return new SapWebAuthenticator(authConfig, profile);

--- a/packages/auth/src/ias-login.ts
+++ b/packages/auth/src/ias-login.ts
@@ -93,9 +93,18 @@ export function isAuthUrl(url: string): boolean {
 }
 
 async function openAuthPage(page: Page, url: string, label: string, logger: Logger): Promise<void> {
-  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
-  await page.waitForLoadState('networkidle', { timeout: 15000 }).catch(() => {
-    logger.warn(`${label} page did not fully settle; continuing with login detection`);
+  try {
+    await page.goto(url, { waitUntil: 'commit', timeout: 45000 });
+  } catch (error) {
+    const currentUrl = page.url();
+    if (!currentUrl || currentUrl === 'about:blank') {
+      throw error;
+    }
+    logger.warn(`${label} navigation did not settle at ${currentUrl}; continuing with login detection`, error);
+  }
+
+  await page.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {
+    logger.warn(`${label} DOMContentLoaded wait timed out; continuing with login detection`);
   });
 }
 


### PR DESCRIPTION
## Goal

Fix SAP API Hub MCP live tool calls failing during browser authentication with `state_not_verified` / navigation timeout behavior.

## Changes

- Authenticate API Hub directly against the API Hub app URL instead of first loading the shared `me.sap.com` bootstrap state.
- Avoid loading the shared SAP SSO storage state for API Hub, because stale OAuth/browser state can poison the API Hub login flow.
- Add API Hub session validation against the categories JSON endpoint before accepting cached or freshly minted cookies.
- Make shared Playwright navigation less brittle by waiting for `commit` first and treating `DOMContentLoaded` as best effort for redirect-heavy auth pages.

## Root Cause

The API Hub auth flow could reuse shared SAP SSO browser state that contained stale API Hub OAuth state. That caused SAP's API Hub OAuth flow to loop through `state_not_verified`, leading to `page.goto` timeouts or unusable cookies.

## Validation

- `npm run typecheck -w @marianfoo/sap-mcp-auth`
- `npm run build -w @marianfoo/sap-mcp-auth`
- `npm run build -w sap-api-hub-mcp`
- Live MCP smoke test:
  - listed API Hub tools
  - `categories` returned 10 categories
  - `search` for `sales order` returned results
