### PR TITLE
fix: symlinked MCP bin startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build (auth → servers)
         run: npm run build
 
+      - name: Smoke test published MCP bins
+        run: npm run smoke:bin
+
       - name: Type check
         run: npm run typecheck
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:auth": "npm run build -w @marianfoo/sap-mcp-auth",
     "clean": "npm run clean --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
+    "smoke:bin": "node scripts/smoke-mcp-bin.mjs packages/api-hub sap-api-hub-mcp sap-api-hub-mcp && node scripts/smoke-mcp-bin.mjs packages/roadmap sap-roadmap-mcp sap-roadmap-mcp",
     "test": "npm run test --workspaces --if-present",
     "install:browsers": "playwright install chromium",
     "commitlint": "commitlint --edit",

--- a/packages/api-hub/src/mcp-server.ts
+++ b/packages/api-hub/src/mcp-server.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from 'node:crypto';
+import { realpathSync } from 'fs';
 import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -547,15 +548,17 @@ function numberValue(value: unknown): number | undefined {
   return typeof value === 'number' ? value : undefined;
 }
 
-const isDirectRun = (() => {
+function isDirectRun(): boolean {
   try {
-    return fileURLToPath(import.meta.url) === resolve(process.argv[1] || '');
+    const thisFile = realpathSync(fileURLToPath(import.meta.url));
+    const invoked = process.argv[1] ? realpathSync(resolve(process.argv[1])) : '';
+    return thisFile === invoked;
   } catch {
     return false;
   }
-})();
+}
 
-if (isDirectRun) {
+if (isDirectRun()) {
   const server = new SapApiHubMcpServer();
 
   const shutdown = async () => {

--- a/packages/roadmap/src/mcp-server.ts
+++ b/packages/roadmap/src/mcp-server.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { randomUUID } from 'node:crypto';
+import { realpathSync } from 'fs';
 import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -394,15 +395,17 @@ function writeJsonRpcError(res: ServerResponse, status: number, message: string)
   }));
 }
 
-const isDirectRun = (() => {
+function isDirectRun(): boolean {
   try {
-    return fileURLToPath(import.meta.url) === resolve(process.argv[1] || '');
+    const thisFile = realpathSync(fileURLToPath(import.meta.url));
+    const invoked = process.argv[1] ? realpathSync(resolve(process.argv[1])) : '';
+    return thisFile === invoked;
   } catch {
     return false;
   }
-})();
+}
 
-if (isDirectRun) {
+if (isDirectRun()) {
   const server = new SapRoadmapMcpServer();
   process.on('SIGINT', () => server.shutdown().then(() => process.exit(0)));
   process.on('SIGTERM', () => server.shutdown().then(() => process.exit(0)));

--- a/scripts/smoke-mcp-bin.mjs
+++ b/scripts/smoke-mcp-bin.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve, join } from 'node:path';
+
+const [packagePath, binName, expectedServerName] = process.argv.slice(2);
+
+if (!packagePath || !binName || !expectedServerName) {
+  console.error('Usage: node scripts/smoke-mcp-bin.mjs <package-path> <bin-name> <expected-server-name>');
+  process.exit(2);
+}
+
+const packageDir = resolve(packagePath);
+const entrypoint = join(packageDir, 'dist', 'mcp-server.js');
+const tempDir = mkdtempSync(join(tmpdir(), `${binName}-`));
+const binPath = join(tempDir, binName);
+let server;
+
+function cleanup() {
+  if (server && server.exitCode === null && !server.killed) {
+    server.kill('SIGTERM');
+  }
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+try {
+  symlinkSync(entrypoint, binPath);
+
+  server = spawn(process.execPath, [binPath], {
+    cwd: packageDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      MCP_MODE: 'true',
+      MCP_TRANSPORT: 'stdio',
+      LOG_LEVEL: 'error'
+    }
+  });
+
+  let stdout = '';
+  let stderr = '';
+  let stdoutBuffer = '';
+
+  const response = await new Promise((resolveResponse, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for ${binName} initialize response.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 5000);
+
+    server.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+
+    server.stdout.on('data', chunk => {
+      const text = chunk.toString();
+      stdout += text;
+      stdoutBuffer += text;
+
+      const lines = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+
+        if (message.id === 1) {
+          clearTimeout(timer);
+          resolveResponse(message);
+        }
+      }
+    });
+
+    server.once('error', error => {
+      clearTimeout(timer);
+      reject(error);
+    });
+
+    server.once('exit', code => {
+      clearTimeout(timer);
+      reject(new Error(`${binName} exited before initialize response with code ${code}.\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    });
+
+    server.stdin.write(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: {
+          name: 'bin-smoke-test',
+          version: '1.0.0'
+        }
+      }
+    })}\n`);
+  });
+
+  assert.equal(response.jsonrpc, '2.0');
+  assert.equal(response.id, 1);
+  assert.equal(response.result?.serverInfo?.name, expectedServerName);
+
+  console.log(`${binName} responded to initialize through symlinked bin path.`);
+} finally {
+  cleanup();
+}


### PR DESCRIPTION
## Summary
- Resolve npm symlinked bin entrypoints before comparing them with the ESM module path, so `sap-api-hub-mcp` starts when invoked through the published npm `bin`.
- Apply the same guard fix to `sap-roadmap-mcp`, which uses the same published-bin pattern.
- Add a CI-safe smoke test that starts both built MCP bins through symlinked paths and expects an `initialize` response.

Fixes #16.

## Root Cause
The direct-run guard compared `fileURLToPath(import.meta.url)` to `resolve(process.argv[1])`. When npm launches a package bin, `process.argv[1]` can be the npm-created symlink while the module URL points at the real file, so the comparison failed and the server startup block was skipped.

## Validation
- `npm run build`
- `npm run smoke:bin`
- `npm run typecheck`