### PR TITLE
fix(notes): fetch SAP for Me backend JSON in-session (fixes search + note content)

### DIFF
--- a/packages/auth/src/authenticator.ts
+++ b/packages/auth/src/authenticator.ts
@@ -36,6 +36,12 @@ export class SapWebAuthenticator {
   private context: BrowserContext | null = null;
   private page: Page | null = null;
   private skipSharedSsoOnce = false;
+  // Live, kept-alive authenticated session for runInSession() (SAP for Me backend
+  // endpoints only serve JSON to a real logged-in browser, not to plain HTTP clients).
+  private liveBrowser: Browser | null = null;
+  private liveContext: BrowserContext | null = null;
+  private livePage: Page | null = null;
+  private liveExpiresAt = 0;
   private readonly log: Logger;
 
   constructor(private readonly config: AuthConfig, private readonly profile: ServiceProfile) {
@@ -78,6 +84,7 @@ export class SapWebAuthenticator {
   async destroy(): Promise<void> {
     this.authState = {};
     await this.cleanup();
+    await this.closeLiveBrowser();
   }
 
   private async performAuth(): Promise<AuthSession> {
@@ -224,61 +231,13 @@ export class SapWebAuthenticator {
       this.skipSharedSsoOnce = false;
     }
 
-    const authMethod = this.resolveAuthMethod();
-    const headless = !this.config.headful;
-    const startTime = Date.now();
-    this.log.warn(`Starting ${this.profile.serviceName} authentication (method: ${authMethod}, headless: ${headless})`);
-
     try {
-      this.browser = await this.launchBrowser(headless);
+      const result = await this.launchAndLogin();
+      this.browser = result.browser;
+      this.context = result.context;
+      this.page = result.page;
 
-      const contextOptions: BrowserContextOptions = {
-        ignoreHTTPSErrors: true,
-        locale: 'en-US',
-        viewport: { width: 1440, height: 900 }
-      };
-      if (this.profile.userAgent) {
-        contextOptions.userAgent = this.profile.userAgent;
-      }
-      if (this.config.ssoStorageStateFile && existsSync(this.config.ssoStorageStateFile)) {
-        contextOptions.storageState = this.config.ssoStorageStateFile;
-        this.log.warn(`Loading shared SAP SSO browser state from ${this.config.ssoStorageStateFile}`);
-      }
-      if (authMethod === 'certificate') {
-        contextOptions.clientCertificates = [this.prepareClientCertificate()];
-      }
-
-      this.context = await this.browser.newContext(contextOptions);
-      this.page = await this.context.newPage();
-      this.page.on('dialog', dialog => {
-        this.log.warn(`Dialog appeared: ${dialog.type()} ${dialog.message()}`);
-        dialog.dismiss().catch(() => {});
-      });
-
-      if (authMethod === 'password') {
-        await performPasswordLogin(this.page, this.config, this.profile, this.log);
-      } else if (authMethod === 'certificate') {
-        await performCertificateNavigation(this.page, this.config, this.profile, this.log);
-      } else {
-        await performInteractiveLogin(this.page, this.config, this.profile, this.log);
-      }
-
-      await this.page.waitForTimeout(1500);
-
-      const allCookies = await this.context.cookies();
-      if (allCookies.length === 0) {
-        throw new AuthenticationError('Authentication appeared to succeed but no cookies were set');
-      }
-
-      const scoped = await selectCookies(this.context, this.profile.cookieScope);
-      const cookieHeader = serializeCookies(scoped);
-      if (!cookieHeader) {
-        throw new AuthenticationError(
-          `${this.profile.serviceName} login completed but no cookies were captured for the configured scope`
-        );
-      }
-
-      if (this.profile.validateSession && !(await this.profile.validateSession(cookieHeader))) {
+      if (this.profile.validateSession && !(await this.profile.validateSession(result.cookieHeader))) {
         throw new AuthenticationError(
           `${this.profile.serviceName} login produced cookies, but the service still rejected the session. ` +
           'Headless username/password login likely requires MFA or another interactive step. ' +
@@ -286,13 +245,19 @@ export class SapWebAuthenticator {
         );
       }
 
-      const expiresAt = Date.now() + this.config.maxSessionAgeH * 60 * 60 * 1000;
-      this.authState = { token: cookieHeader, cookies: scoped, expiresAt, authMethod };
+      this.authState = {
+        token: result.cookieHeader,
+        cookies: result.scoped,
+        expiresAt: result.expiresAt,
+        authMethod: result.authMethod
+      };
 
-      saveCachedToken(this.config.tokenCacheFile, { access_token: cookieHeader, cookies: scoped, expiresAt, authMethod }, this.log);
-      await saveSharedSsoStorageState(this.context, this.config.ssoStorageStateFile, this.log);
-
-      this.log.warn(`${this.profile.serviceName} authentication completed in ${Date.now() - startTime}ms (method: ${authMethod})`);
+      saveCachedToken(
+        this.config.tokenCacheFile,
+        { access_token: result.cookieHeader, cookies: result.scoped, expiresAt: result.expiresAt, authMethod: result.authMethod },
+        this.log
+      );
+      await saveSharedSsoStorageState(result.context, this.config.ssoStorageStateFile, this.log);
     } catch (error) {
       this.authState = {};
       const message = error instanceof Error ? error.message : String(error);
@@ -300,6 +265,133 @@ export class SapWebAuthenticator {
       throw error;
     } finally {
       await this.cleanup();
+    }
+  }
+
+  /**
+   * Launch a browser, open a context (reusing SSO storage state when present), perform the
+   * resolved login flow, and return the live handles plus the captured session cookies.
+   * Shared by performAuth() (which captures cookies then closes the browser) and
+   * ensureLivePage() (which keeps the browser alive for runInSession()).
+   */
+  private async launchAndLogin(): Promise<{
+    browser: Browser;
+    context: BrowserContext;
+    page: Page;
+    cookieHeader: string;
+    scoped: Cookie[];
+    authMethod: ResolvedAuthMethod;
+    expiresAt: number;
+  }> {
+    const authMethod = this.resolveAuthMethod();
+    const headless = !this.config.headful;
+    const startTime = Date.now();
+    this.log.warn(`Starting ${this.profile.serviceName} authentication (method: ${authMethod}, headless: ${headless})`);
+
+    const browser = await this.launchBrowser(headless);
+
+    const contextOptions: BrowserContextOptions = {
+      ignoreHTTPSErrors: true,
+      locale: 'en-US',
+      viewport: { width: 1440, height: 900 }
+    };
+    if (this.profile.userAgent) {
+      contextOptions.userAgent = this.profile.userAgent;
+    }
+    if (this.config.ssoStorageStateFile && existsSync(this.config.ssoStorageStateFile)) {
+      contextOptions.storageState = this.config.ssoStorageStateFile;
+      this.log.warn(`Loading shared SAP SSO browser state from ${this.config.ssoStorageStateFile}`);
+    }
+    if (authMethod === 'certificate') {
+      contextOptions.clientCertificates = [this.prepareClientCertificate()];
+    }
+
+    const context = await browser.newContext(contextOptions);
+    const page = await context.newPage();
+    page.on('dialog', dialog => {
+      this.log.warn(`Dialog appeared: ${dialog.type()} ${dialog.message()}`);
+      dialog.dismiss().catch(() => {});
+    });
+
+    if (authMethod === 'password') {
+      await performPasswordLogin(page, this.config, this.profile, this.log);
+    } else if (authMethod === 'certificate') {
+      await performCertificateNavigation(page, this.config, this.profile, this.log);
+    } else {
+      await performInteractiveLogin(page, this.config, this.profile, this.log);
+    }
+
+    await page.waitForTimeout(1500);
+
+    const allCookies = await context.cookies();
+    if (allCookies.length === 0) {
+      throw new AuthenticationError('Authentication appeared to succeed but no cookies were set');
+    }
+
+    const scoped = await selectCookies(context, this.profile.cookieScope);
+    const cookieHeader = serializeCookies(scoped);
+    if (!cookieHeader) {
+      throw new AuthenticationError(
+        `${this.profile.serviceName} login completed but no cookies were captured for the configured scope`
+      );
+    }
+
+    const expiresAt = Date.now() + this.config.maxSessionAgeH * 60 * 60 * 1000;
+    this.log.warn(`${this.profile.serviceName} authentication completed in ${Date.now() - startTime}ms (method: ${authMethod})`);
+    return { browser, context, page, cookieHeader, scoped, authMethod, expiresAt };
+  }
+
+  /**
+   * Run a callback inside a live, authenticated browser page, kept alive across calls.
+   * SAP for Me backend endpoints (/backend/raw/...) return a JS-bootstrap HTML stub to plain
+   * HTTP clients and only serve JSON to a real logged-in browser, so consumers that need those
+   * endpoints must run their fetches in-page via this method rather than with the cookie header.
+   */
+  async runInSession<T>(fn: (page: Page) => Promise<T>): Promise<T> {
+    const page = await this.ensureLivePage();
+    return fn(page);
+  }
+
+  /** Force the next runInSession() call to perform a fresh login. */
+  invalidateLiveSession(): void {
+    this.liveExpiresAt = 0;
+  }
+
+  private async ensureLivePage(): Promise<Page> {
+    if (this.livePage && !this.livePage.isClosed() && Date.now() < this.liveExpiresAt - EXPIRY_BUFFER_MS) {
+      return this.livePage;
+    }
+    await this.closeLiveBrowser();
+
+    const result = await this.launchAndLogin();
+    this.liveBrowser = result.browser;
+    this.liveContext = result.context;
+    this.livePage = result.page;
+    this.liveExpiresAt = result.expiresAt;
+
+    // Keep the memory + disk session in sync so ensureSession() consumers benefit too.
+    this.authState = {
+      token: result.cookieHeader,
+      cookies: result.scoped,
+      expiresAt: result.expiresAt,
+      authMethod: result.authMethod
+    };
+    saveCachedToken(
+      this.config.tokenCacheFile,
+      { access_token: result.cookieHeader, cookies: result.scoped, expiresAt: result.expiresAt, authMethod: result.authMethod },
+      this.log
+    );
+    await saveSharedSsoStorageState(result.context, this.config.ssoStorageStateFile, this.log);
+
+    return this.livePage;
+  }
+
+  private async closeLiveBrowser(): Promise<void> {
+    if (this.liveBrowser) {
+      await this.liveBrowser.close().catch(error => this.log.warn('Failed to close live browser', error));
+      this.liveBrowser = null;
+      this.liveContext = null;
+      this.livePage = null;
     }
   }
 

--- a/packages/notes/src/mcp-server.ts
+++ b/packages/notes/src/mcp-server.ts
@@ -62,7 +62,7 @@ class SapNoteMcpServer {
   constructor() {
     this.config = this.loadConfig();
     this.authenticator = createNotesAuthenticator(this.config);
-    this.sapNotesClient = new SapNotesApiClient(this.config);
+    this.sapNotesClient = new SapNotesApiClient(this.config, this.authenticator);
     
     // Create MCP server with official SDK
     this.mcpServer = new McpServer({
@@ -304,6 +304,7 @@ class SapNoteMcpServer {
           if (noteDetail.manualActions) output.manualActions = noteDetail.manualActions;
           if (noteDetail.attachments?.length) output.attachments = noteDetail.attachments;
           if (noteDetail.downloadUrl) output.downloadUrl = noteDetail.downloadUrl;
+          if (noteDetail.pdfUrl) output.pdfUrl = noteDetail.pdfUrl;
 
           // Format display text
           let resultText = `**SAP Note ${output.id} - ${output.title}**\n\n`;

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -1,7 +1,13 @@
 import type { ServerConfig } from './types.js';
+import type { SapWebAuthenticator } from '@marianfoo/sap-mcp-auth';
 import { logger } from './logger.js';
 import { existsSync } from 'fs';
 import { chromium, type Browser, type BrowserContextOptions, type Page } from 'playwright';
+
+/** SAP for Me backend paths (called in-page via runInSession). */
+const NOTES_DETAIL_PATH = '/backend/raw/sapnotes/Detail';
+const NOTES_SEARCH_PATH =
+  '/backend/raw/core/W7LegacyProxyVerticle/odata/sfm/snogwsmynotes/SAPNotes';
 
 export interface SapNoteResult {
   id: string;
@@ -79,14 +85,24 @@ export interface SapNoteDetail {
   };
   attachments?: Array<{ filename: string; url?: string }>;
   downloadUrl?: string;
+  /** Ready-to-use PDF ("Print") URL for the note, when SAP for Me provides one. */
+  pdfUrl?: string;
 }
 
 /**
- * SAP Notes API Client - Uses Coveo Search API
- * SAP uses Coveo as their search infrastructure for SAP Notes
+ * SAP Notes API Client.
+ *
+ * Primary data path: the SAP for Me backend JSON endpoints, called *inside* a live authenticated
+ * browser page via `SapWebAuthenticator.runInSession()`. Those endpoints return a JS-bootstrap HTML
+ * stub to plain HTTP clients (cookie header included) and only serve JSON to a real logged-in
+ * browser, so in-page `fetch` is the only reliable way to reach them:
+ *   - search  : /backend/raw/core/W7LegacyProxyVerticle/odata/sfm/snogwsmynotes/SAPNotes
+ *   - content : /backend/raw/sapnotes/Detail?q=<id>   -> Response.SAPNote (incl. LongText + PDF url)
+ * The legacy Coveo search path is kept only as a fallback for setups without an authenticator.
  */
 export class SapNotesApiClient {
   private config: ServerConfig;
+  private authenticator?: SapWebAuthenticator;
   private baseUrl = 'https://launchpad.support.sap.com';
   private rawNotesUrl = 'https://me.sap.com/backend/raw/sapnotes';
   private coveoSearchUrl = 'https://sapamericaproductiontyfzmfz0.org.coveo.com/rest/search/v2';
@@ -102,8 +118,136 @@ export class SapNotesApiClient {
   private coveoTokenCache: { token: string; expiresAt: number } | null = null;
   private readonly COVEO_TOKEN_TTL = 14 * 60 * 1000; // Cache for 14 minutes (conservative)
 
-  constructor(config: ServerConfig) {
+  constructor(config: ServerConfig, authenticator?: SapWebAuthenticator) {
     this.config = config;
+    this.authenticator = authenticator;
+  }
+
+  /**
+   * Fetch a SAP for Me backend path as JSON from inside the live authenticated browser page.
+   * Returns null when no authenticator is wired up (callers then use their legacy path).
+   */
+  private async fetchBackendJson<T = any>(path: string): Promise<T | null> {
+    if (!this.authenticator) return null;
+    return this.authenticator.runInSession(async page => {
+      if (!page.url().includes('me.sap.com')) {
+        await page.goto('https://me.sap.com/home', { waitUntil: 'domcontentloaded', timeout: 45000 });
+        await page.waitForTimeout(2000);
+      }
+      const result = await page.evaluate(async (url: string) => {
+        const response = await fetch(url, {
+          headers: { Accept: 'application/json' },
+          credentials: 'include'
+        });
+        return { status: response.status, body: await response.text() };
+      }, path);
+
+      if (result.status === 401 || result.status === 403) {
+        throw new Error(`SESSION_EXPIRED: backend returned ${result.status} for ${path}`);
+      }
+      if (result.status !== 200) {
+        throw new Error(`Backend request failed (${result.status}) for ${path}`);
+      }
+      try {
+        return JSON.parse(result.body) as T;
+      } catch {
+        // A JS/login stub instead of JSON means the page is not authenticated any more.
+        throw new Error(`SESSION_EXPIRED: backend returned non-JSON for ${path}`);
+      }
+    });
+  }
+
+  /** Convert an OData v2 date literal (`/Date(1755008055000)/`) to `YYYY-MM-DD`. */
+  private parseODataDate(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const match = value.match(/\/Date\((-?\d+)/);
+    if (!match) return null;
+    const date = new Date(Number.parseInt(match[1], 10));
+    return Number.isNaN(date.getTime()) ? null : date.toISOString().split('T')[0];
+  }
+
+  /**
+   * Search SAP Notes through the snogwsmynotes OData service (in-page, authenticated).
+   * Full-text matching uses the FilterKeywordsFuzzy property; plain OData `search=` returns nothing.
+   */
+  private async searchViaBackend(query: string, maxResults: number): Promise<SapNoteSearchResponse | null> {
+    const filter = `FilterKeywordsFuzzy eq '${query.replace(/'/g, "''")}'`;
+    const url =
+      `${NOTES_SEARCH_PATH}?$top=${maxResults}&$inlinecount=allpages` +
+      `&$orderby=${encodeURIComponent('Relevance desc')}&$filter=${encodeURIComponent(filter)}`;
+
+    const json = await this.fetchBackendJson<any>(url);
+    if (!json) return null;
+
+    const rows: any[] = json?.d?.results ?? [];
+    const results: SapNoteResult[] = rows.map(row => {
+      const id = String(row.Number ?? '').replace(/^0+/, '') || String(row.Number ?? '');
+      // The OData URL field is a site-relative path (e.g. /notes/0002137318); make it absolute
+      // so it satisfies the tool output schema.
+      const rawUrl = typeof row.URL === 'string' ? row.URL.trim() : '';
+      const url = /^https?:\/\//i.test(rawUrl)
+        ? rawUrl
+        : rawUrl
+          ? `https://me.sap.com${rawUrl.startsWith('/') ? '' : '/'}${rawUrl}`
+          : `https://me.sap.com/notes/${id}`;
+      return {
+        id,
+        title: row.Title || `SAP Note ${row.Number}`,
+        summary: row.ComponentName || row.Category || 'SAP Note',
+        component: row.Component || undefined,
+        releaseDate: this.parseODataDate(row.ReleasedOn) || row.ReleasedOn || 'Unknown',
+        language: 'EN',
+        url
+      };
+    });
+
+    const total = Number.parseInt(json?.d?.__count ?? '', 10);
+    logger.info(`✅ Found ${results.length} SAP Note(s) via SAP for Me backend search`);
+    return { results, totalResults: Number.isNaN(total) ? results.length : total, query };
+  }
+
+  /**
+   * Fetch a note's full content + metadata from /backend/raw/sapnotes/Detail (in-page, authenticated).
+   */
+  private async getNoteViaBackend(noteId: string): Promise<SapNoteDetail | null> {
+    const json = await this.fetchBackendJson<any>(`${NOTES_DETAIL_PATH}?q=${encodeURIComponent(noteId)}`);
+    if (!json) return null;
+
+    const sapNote = json?.Response?.SAPNote;
+    if (!sapNote) {
+      logger.warn(`Detail response for note ${noteId} contained no SAPNote payload`);
+      return null;
+    }
+
+    const header = sapNote.Header || {};
+    const detail: SapNoteDetail = {
+      id: header.Number?.value || noteId,
+      title: sapNote.Title?.value || `SAP Note ${noteId}`,
+      summary: header.Type?.value || 'SAP Note',
+      content: sapNote.LongText?.value || 'No content available',
+      language: header.Language?.value || 'EN',
+      releaseDate: header.ReleasedOn?.value || 'Unknown',
+      component: header.SAPComponentKey?.value,
+      componentText: header.SAPComponentKeyText?.value,
+      priority: header.Priority?.value,
+      category: header.Category?.value,
+      version: header.Version?.value != null ? String(header.Version.value) : undefined,
+      status: header.Status?.value,
+      url: `https://me.sap.com/notes/${header.Number?.value || noteId}`
+    };
+
+    // "PDF Version" action carries a ready-to-use, token-bearing PDF URL.
+    const printUrl = sapNote.Actions?.Print?.url;
+    if (printUrl) detail.pdfUrl = printUrl;
+
+    try {
+      this.extractEnrichedMetadata(sapNote, detail);
+    } catch (error) {
+      logger.warn(`⚠️ Enriched metadata extraction failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    logger.info(`✅ Retrieved SAP Note ${noteId} via SAP for Me backend (${detail.content.length} chars)`);
+    return detail;
   }
 
   /**
@@ -113,8 +257,17 @@ export class SapNotesApiClient {
     logger.info(`🔍 Searching SAP Notes for: "${query}"`);
     logger.debug(`📊 Search parameters: query="${query}", maxResults=${maxResults}`);
 
+    // Primary: the SAP for Me backend OData search, run inside the authenticated browser page.
     try {
-      // Try primary Coveo search approach
+      const backendResults = await this.searchViaBackend(query, maxResults);
+      if (backendResults) return backendResults;
+    } catch (backendError) {
+      const message = backendError instanceof Error ? backendError.message : String(backendError);
+      logger.warn(`⚠️ SAP for Me backend search failed, falling back: ${message}`);
+    }
+
+    try {
+      // Legacy Coveo search approach (fallback)
       try {
         logger.debug('🔍 Attempting primary Coveo search...');
         
@@ -272,8 +425,17 @@ export class SapNotesApiClient {
   async getNote(noteId: string, token: string): Promise<SapNoteDetail | null> {
     logger.info(`📄 Fetching SAP Note: ${noteId}`);
 
+    // Primary: /backend/raw/sapnotes/Detail fetched inside the authenticated browser page.
     try {
-      // Try Playwright-based raw notes API first (most likely to get actual content)
+      const backendNote = await this.getNoteViaBackend(noteId);
+      if (backendNote) return backendNote;
+    } catch (backendError) {
+      const message = backendError instanceof Error ? backendError.message : String(backendError);
+      logger.warn(`⚠️ SAP for Me backend Detail failed, falling back: ${message}`);
+    }
+
+    try {
+      // Legacy Playwright page-navigation approach (fallback)
       try {
         logger.info(`🎭 Trying Playwright approach for note ${noteId}`);
         const note = await this.getNoteWithPlaywright(noteId, token);

--- a/packages/notes/src/schemas/sap-notes.ts
+++ b/packages/notes/src/schemas/sap-notes.ts
@@ -277,6 +277,11 @@ export const NoteGetOutputSchema = {
     .string()
     .optional()
     .describe('SNOTE download URL for automatic correction import.'),
+
+  pdfUrl: z
+    .string()
+    .optional()
+    .describe('Ready-to-use PDF version URL of the note, when SAP for Me provides one.'),
 };
 
 // ─── TOOL DESCRIPTIONS ─────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #30.

## Problem

Both notes tools were broken against the current SAP for Me backend:

- **`fetch`** returned the placeholder *"This SAP Note exists but its content requires browser navigation to access"* instead of the note body.
- **`search`** failed with `Coveo token extraction failed: SESSION_EXPIRED` (the Coveo app/token call returns **401**, and the internal fallback `/backend/raw/sapnotes/Search` returns **404** — that route no longer exists).

Root cause: `me.sap.com/backend/...` returns a **JS-bootstrap HTML stub to any plain HTTP client** — even with a valid cookie header — and only serves JSON to a real logged-in browser. So no cookie-based HTTP path can work; the request has to run *inside* the authenticated page.

(Secondary bug found on the way: the HTTP fallback parser checked `jsonData.SapNote`, but the real shape is `jsonData.Response.SAPNote` — so even a good response fell through to the placeholder.)

## Change

**`packages/auth`** — add `runInSession(fn)`: runs a callback inside a live, kept-alive authenticated page (with `invalidateLiveSession()` to force a fresh login). This is the piece consumers need to reach browser-only backend endpoints.

**`packages/notes`** — use it for both tools:

| | endpoint |
|---|---|
| `search` | `…/odata/sfm/snogwsmynotes/SAPNotes?$filter=FilterKeywordsFuzzy eq '<query>'&$orderby=Relevance desc&$inlinecount=allpages` |
| `fetch` | `/backend/raw/sapnotes/Detail?q=<id>` → parsed from `Response.SAPNote` |

Notes on the search endpoint: plain OData `search=` returns `[]` — full-text matching only works through `FilterKeywordsFuzzy` (there is also `FilterKeywordsExact`, plus facet properties `FilterComponent` / `FilterProduct` / `FilterSupportPackage` / `FilterDocumentType` / …, if you want to expose filters later).

Also included:
- **new**: the note's PDF URL is surfaced as `pdfUrl` (from `Actions.Print.url`, which carries a ready-to-use token).
- OData v2 dates (`/Date(1755008055000)/`) normalised to `YYYY-MM-DD`.
- the site-relative `URL` field made absolute (it otherwise fails the tool's output schema with `Invalid URL`).

The legacy Coveo/Playwright paths are **kept as fallbacks**, and the authenticator is an **optional** constructor arg — so anything constructing `SapNotesApiClient` without one behaves exactly as before.

## Verification

Run locally against a real S-user, headless, password auth:

```
search "SYB ASE start stop database" → 338 hits; top: 2137318 "SYB: Start and stop database ASE with HADR" (BC-DB-SYB)
search "kernel patch disp+work"      → 4193 hits; correct dates + absolute URLs
fetch  2137318                        → full LongText, component BC-DB-SYB, v68, released date, pdfUrl present
```

`npm run build` (tsc clean) plus `test:auth`, `test:api` and `test:mcp` all pass. The `test:mcp` run initially caught the relative-URL schema failure, which is fixed in this branch.

## Note for other users hitting auth problems

Unrelated to this fix, but it cost me hours and may explain other reports: **dotenv strips `#` as an inline comment**, so an unquoted `SAP_PASSWORD=My#Pass` silently becomes `My`. That looks exactly like an MFA/IdP hang (login submits, then waits for a redirect that never comes). Quoting the value fixes it. Might be worth a line in the README / `.env.example`.

Happy to adjust naming, split the auth and notes changes into separate commits, or drop the `pdfUrl` addition if you'd rather keep this strictly a fix.
