### PR TITLE
fix(notes): restore authenticated SAP backend access

### DIFF
--- a/packages/notes/package.json
+++ b/packages/notes/package.json
@@ -30,6 +30,7 @@
     "test:mcp:debug": "npm run build && LOG_LEVEL=debug DOCKER_ENV=true node test/test-mcp-server.js",
     "test:api": "npm run build && node test/test-sap-api.js",
     "test:flow": "npm run build && node test/test-full-flow.js",
+    "test:unit": "npm run build && node --test test/*.unit.test.js",
     "test": "npm run test:auth && npm run test:api && npm run test:mcp",
     "debug:container": "./debug-container.sh",
     "clean": "rimraf dist"

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -1,7 +1,23 @@
 import type { ServerConfig } from './types.js';
 import { logger } from './logger.js';
 import { existsSync } from 'fs';
-import { chromium, type Browser, type BrowserContextOptions, type Page } from 'playwright';
+import {
+  chromium,
+  request,
+  type APIRequestContext,
+  type Browser,
+  type BrowserContextOptions,
+  type Page
+} from 'playwright';
+import {
+  SAP_NOTES_DETAIL_PATH,
+  SAP_NOTES_SEARCH_PATH,
+  buildSapNotesSearchParams,
+  extractSapNotePayload,
+  extractSapNotesBackendError,
+  isAuthenticationBootstrapResponse,
+  mapSapNotesSearchResponse
+} from './sap-notes-backend.js';
 
 export interface SapNoteResult {
   id: string;
@@ -102,8 +118,173 @@ export class SapNotesApiClient {
   private coveoTokenCache: { token: string; expiresAt: number } | null = null;
   private readonly COVEO_TOKEN_TTL = 14 * 60 * 1000; // Cache for 14 minutes (conservative)
 
+  // SAP for Me backend requests use Playwright's authenticated HTTP context. Unlike
+  // native fetch, it can initialize directly from Playwright storage state and receives
+  // backend JSON without retaining a browser process.
+  private backendRequestContext: APIRequestContext | null = null;
+  private backendRequestContextPromise: Promise<APIRequestContext> | null = null;
+
   constructor(config: ServerConfig) {
     this.config = config;
+  }
+
+  private async loadBackendStorageState(
+    token: string
+  ): Promise<Exclude<BrowserContextOptions['storageState'], string | undefined> | undefined> {
+    if (this.config.ssoStorageStateFile && existsSync(this.config.ssoStorageStateFile)) {
+      try {
+        const { readFileSync } = await import('fs');
+        const rawState = JSON.parse(readFileSync(this.config.ssoStorageStateFile, 'utf-8'));
+        const cookies = this.sanitizeCookiesForStorageState(
+          Array.isArray(rawState.cookies) ? rawState.cookies : []
+        );
+
+        if (cookies.length > 0) {
+          return {
+            cookies,
+            origins: Array.isArray(rawState.origins) ? rawState.origins : []
+          };
+        }
+      } catch (error) {
+        logger.warn(
+          `Failed to load SAP SSO storage state for backend requests: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    const tokenState = await this.buildStorageStateFromTokenCache(token);
+    return typeof tokenState === 'object' ? tokenState : undefined;
+  }
+
+  private async ensureBackendRequestContext(token: string): Promise<APIRequestContext> {
+    if (this.backendRequestContext) return this.backendRequestContext;
+    if (this.backendRequestContextPromise) return this.backendRequestContextPromise;
+
+    this.backendRequestContextPromise = (async () => {
+      const storageState = await this.loadBackendStorageState(token);
+      if (!storageState) {
+        throw new Error('SESSION_EXPIRED: no SAP cookies were available for backend requests');
+      }
+
+      return request.newContext({
+        baseURL: 'https://me.sap.com',
+        storageState,
+        ignoreHTTPSErrors: true,
+        extraHTTPHeaders: { Accept: 'application/json' },
+        timeout: 30000
+      });
+    })();
+
+    try {
+      this.backendRequestContext = await this.backendRequestContextPromise;
+      return this.backendRequestContext;
+    } finally {
+      this.backendRequestContextPromise = null;
+    }
+  }
+
+  private async invalidateBackendRequestContext(): Promise<void> {
+    const context = this.backendRequestContext;
+    this.backendRequestContext = null;
+    if (context) {
+      await context.dispose({ reason: 'SAP Notes session invalidated' }).catch(() => {});
+    }
+  }
+
+  private async fetchBackendJson(
+    path: string,
+    token: string,
+    params?: URLSearchParams | Record<string, string>
+  ): Promise<unknown> {
+    const context = await this.ensureBackendRequestContext(token);
+    const response = await context.get(path, { params, failOnStatusCode: false });
+
+    let body = '';
+    try {
+      body = await response.text();
+      const status = response.status();
+      const contentType = response.headers()['content-type'];
+
+      if (isAuthenticationBootstrapResponse(status, contentType, body)) {
+        await this.invalidateBackendRequestContext();
+        throw new Error(`SESSION_EXPIRED: SAP backend rejected the session for ${path}`);
+      }
+      if (!response.ok()) {
+        throw new Error(`SAP backend request failed (${status}) for ${path}`);
+      }
+
+      try {
+        return JSON.parse(body);
+      } catch {
+        throw new Error(`SAP backend returned non-JSON content for ${path}`);
+      }
+    } finally {
+      await response.dispose().catch(() => {});
+    }
+  }
+
+  private buildNoteDetail(sapNote: any, noteId: string): SapNoteDetail {
+    const header = sapNote.Header || {};
+    const detail: SapNoteDetail = {
+      id: header.Number?.value || noteId,
+      title: sapNote.Title?.value || `SAP Note ${noteId}`,
+      summary: header.Type?.value || 'SAP Knowledge Base Article',
+      content: sapNote.LongText?.value || 'No content available',
+      language: header.Language?.value || 'EN',
+      releaseDate: header.ReleasedOn?.value || 'Unknown',
+      component: header.SAPComponentKey?.value,
+      componentText: header.SAPComponentKeyText?.value,
+      priority: header.Priority?.value,
+      category: header.Category?.value,
+      version: header.Version?.value != null ? String(header.Version.value) : undefined,
+      status: header.Status?.value,
+      url: `https://me.sap.com/notes/${header.Number?.value || noteId}`
+    };
+
+    this.extractEnrichedMetadata(sapNote, detail);
+    return detail;
+  }
+
+  private async searchViaBackend(
+    query: string,
+    token: string,
+    maxResults: number
+  ): Promise<SapNoteSearchResponse> {
+    const payload = await this.fetchBackendJson(
+      SAP_NOTES_SEARCH_PATH,
+      token,
+      buildSapNotesSearchParams(query, maxResults)
+    );
+    const result = mapSapNotesSearchResponse(payload, query);
+    logger.info(`✅ Found ${result.results.length} SAP Note(s) via SAP for Me backend`);
+    return result;
+  }
+
+  private async getNoteViaBackend(noteId: string, token: string): Promise<SapNoteDetail | null> {
+    const payload = await this.fetchBackendJson(
+      SAP_NOTES_DETAIL_PATH,
+      token,
+      { q: noteId }
+    );
+    const sapNote = extractSapNotePayload(payload);
+    if (!sapNote) {
+      const backendError = extractSapNotesBackendError(payload);
+      if (backendError?.code === 'DOES_NOT_EXIST') {
+        logger.info(`SAP Note ${noteId} does not exist`);
+        return null;
+      }
+
+      const detail = [backendError?.code, backendError?.message].filter(Boolean).join(': ');
+      throw new Error(
+        detail
+          ? `SAP backend Detail error: ${detail}`
+          : 'SAP backend Detail response did not contain Response.SAPNote'
+      );
+    }
+
+    const detail = this.buildNoteDetail(sapNote, noteId);
+    logger.info(`✅ Retrieved SAP Note ${noteId} via SAP for Me backend`);
+    return detail;
   }
 
   /**
@@ -114,6 +295,16 @@ export class SapNotesApiClient {
     logger.debug(`📊 Search parameters: query="${query}", maxResults=${maxResults}`);
 
     try {
+      // Primary path: SAP for Me's authenticated OData search. This avoids the
+      // Coveo bootstrap/token flow and returns stable backend data directly.
+      try {
+        return await this.searchViaBackend(query, token, maxResults);
+      } catch (backendError) {
+        const message = backendError instanceof Error ? backendError.message : String(backendError);
+        if (message.includes('SESSION_EXPIRED')) throw backendError;
+        logger.warn(`⚠️ SAP for Me backend search failed, falling back to Coveo: ${message}`);
+      }
+
       // Try primary Coveo search approach
       try {
         logger.debug('🔍 Attempting primary Coveo search...');
@@ -273,6 +464,17 @@ export class SapNotesApiClient {
     logger.info(`📄 Fetching SAP Note: ${noteId}`);
 
     try {
+      // Primary path: the authenticated SAP for Me Detail endpoint. Session errors
+      // must propagate so the server can invalidate auth and retry with fresh state.
+      try {
+        const backendNote = await this.getNoteViaBackend(noteId, token);
+        if (backendNote) return backendNote;
+      } catch (backendError) {
+        const message = backendError instanceof Error ? backendError.message : String(backendError);
+        if (message.includes('SESSION_EXPIRED')) throw backendError;
+        logger.warn(`⚠️ SAP for Me backend Detail failed, trying legacy fallbacks: ${message}`);
+      }
+
       // Try Playwright-based raw notes API first (most likely to get actual content)
       try {
         logger.info(`🎭 Trying Playwright approach for note ${noteId}`);
@@ -283,6 +485,7 @@ export class SapNotesApiClient {
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('SESSION_EXPIRED')) throw error;
         logger.warn(`⚠️ Playwright approach failed: ${errorMessage}, trying HTTP fallbacks`);
       }
 
@@ -298,6 +501,7 @@ export class SapNotesApiClient {
         }
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
+        if (errorMessage.includes('SESSION_EXPIRED')) throw error;
         logger.debug(`Raw notes HTTP API failed: ${errorMessage}, trying OData fallbacks`);
       }
 
@@ -318,6 +522,7 @@ export class SapNotesApiClient {
           }
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);
+          if (errorMessage.includes('SESSION_EXPIRED')) throw error;
           logger.warn(`⚠️ Endpoint ${endpoint} failed: ${errorMessage}`);
         }
       }
@@ -1001,6 +1206,7 @@ export class SapNotesApiClient {
    * Cleanup method - call this when shutting down the server
    */
   async cleanup(): Promise<void> {
+    await this.invalidateBackendRequestContext();
     if (this.browser) {
       logger.debug('🧹 Closing persistent browser session');
       await this.browser.close().catch(() => {});
@@ -1415,7 +1621,12 @@ export class SapNotesApiClient {
     
     try {
       const jsonData = JSON.parse(responseText);
-      
+
+      const sapNote = extractSapNotePayload(jsonData);
+      if (sapNote) {
+        return this.buildNoteDetail(sapNote, noteId);
+      }
+
       // Check if we have a valid note response
       if (jsonData && (jsonData.SapNote || jsonData.id || jsonData.noteId)) {
         return {
@@ -1435,26 +1646,17 @@ export class SapNotesApiClient {
       logger.debug('Raw note response is not JSON, checking for HTML redirect/content');
     }
 
-    // Check if this is a redirect page that indicates the note exists
-    if (responseText.includes('fragmentAfterLogin') || responseText.includes('document.cookie')) {
-      logger.debug('Detected redirect page, note likely exists but requires browser navigation');
-      
-      // If we got a response for a valid note ID, create a basic result
-      if (noteId && noteId.match(/^\d{6,8}$/)) {
-        return {
-          id: noteId,
-          title: `SAP Note ${noteId}`,
-          summary: 'Note found via raw API - full content requires browser access',
-          content: `This SAP Note exists but its content requires browser navigation to access.\n\nTo view the complete note content:\n1. Visit: https://launchpad.support.sap.com/#/notes/${noteId}\n2. Or access through: https://me.sap.com with your SAP credentials\n\nThe note was successfully located but content extraction requires additional authentication steps.`,
-          language: 'EN',
-          releaseDate: 'Unknown',
-          url: `https://launchpad.support.sap.com/#/notes/${noteId}`
-        };
-      }
+    // SAP returns a 200 HTML bootstrap page for invalid sessions. Treating it as
+    // a note hid auth expiry from the server retry and produced false success.
+    if (isAuthenticationBootstrapResponse(
+      response.status,
+      response.headers.get('content-type') ?? undefined,
+      responseText
+    )) {
+      throw new Error('SESSION_EXPIRED: raw Detail endpoint returned the SAP login bootstrap');
     }
 
-    // Fallback to HTML parsing
-    return this.parseHtmlForNoteDetail(responseText, noteId);
+    return null;
   }
 
   /**

--- a/packages/notes/src/sap-notes-backend.ts
+++ b/packages/notes/src/sap-notes-backend.ts
@@ -1,0 +1,130 @@
+import type { SapNoteResult, SapNoteSearchResponse } from './sap-notes-api.js';
+
+export const SAP_NOTES_DETAIL_PATH = '/backend/raw/sapnotes/Detail';
+export const SAP_NOTES_SEARCH_PATH =
+  '/backend/raw/core/W7LegacyProxyVerticle/odata/sfm/snogwsmynotes/SAPNotes';
+
+export interface SapNotesBackendError {
+  code?: string;
+  message?: string;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): JsonRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as JsonRecord
+    : null;
+}
+
+function asText(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+}
+
+export function buildSapNotesSearchParams(query: string, maxResults: number): URLSearchParams {
+  const top = Number.isFinite(maxResults)
+    ? Math.min(100, Math.max(1, Math.trunc(maxResults)))
+    : 10;
+  const escapedQuery = query.replace(/'/g, "''");
+
+  return new URLSearchParams({
+    $top: String(top),
+    $inlinecount: 'allpages',
+    $orderby: 'Relevance desc',
+    $filter: `FilterKeywordsFuzzy eq '${escapedQuery}'`
+  });
+}
+
+export function parseODataDate(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const match = value.match(/\/Date\((-?\d+)/);
+  if (!match) return null;
+
+  const date = new Date(Number.parseInt(match[1], 10));
+  return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
+}
+
+function normalizeNoteUrl(value: unknown, noteId: string): string {
+  const rawUrl = typeof value === 'string' ? value.trim() : '';
+  if (!rawUrl) return `https://me.sap.com/notes/${noteId}`;
+
+  try {
+    return new URL(rawUrl, 'https://me.sap.com').toString();
+  } catch {
+    return `https://me.sap.com/notes/${noteId}`;
+  }
+}
+
+export function mapSapNotesSearchResponse(
+  payload: unknown,
+  query: string
+): SapNoteSearchResponse {
+  const root = asRecord(payload);
+  const data = asRecord(root?.d);
+  if (!data || !Array.isArray(data.results)) {
+    throw new Error('SAP Notes search response did not contain d.results');
+  }
+
+  const results: SapNoteResult[] = data.results.flatMap(value => {
+    const row = asRecord(value);
+    if (!row) return [];
+
+    const rawId = asText(row.Number) ?? '';
+    const noteId = rawId.replace(/^0+/, '') || rawId;
+    if (!noteId) return [];
+
+    return [{
+      id: noteId,
+      title: asText(row.Title) || `SAP Note ${noteId}`,
+      summary: asText(row.ComponentName) || asText(row.Category) || 'SAP Note',
+      language: 'EN',
+      releaseDate: parseODataDate(row.ReleasedOn) || asText(row.ReleasedOn) || 'Unknown',
+      component: asText(row.Component),
+      url: normalizeNoteUrl(row.URL, noteId)
+    }];
+  });
+
+  const parsedTotal = Number.parseInt(asText(data.__count) ?? '', 10);
+  return {
+    results,
+    totalResults: Number.isNaN(parsedTotal) ? results.length : parsedTotal,
+    query
+  };
+}
+
+export function extractSapNotePayload(payload: unknown): JsonRecord | null {
+  const root = asRecord(payload);
+  const response = asRecord(root?.Response);
+  const sapNote = asRecord(response?.SAPNote);
+  return sapNote && Object.keys(sapNote).length > 0 ? sapNote : null;
+}
+
+export function extractSapNotesBackendError(payload: unknown): SapNotesBackendError | null {
+  const root = asRecord(payload);
+  const response = asRecord(root?.Response);
+  const error = asRecord(response?.Error);
+  if (!error) return null;
+
+  const code = asText(error.Code);
+  const message = asText(error.Message);
+  return code || message ? { code, message } : null;
+}
+
+export function isAuthenticationBootstrapResponse(
+  status: number,
+  contentType: string | undefined,
+  body: string
+): boolean {
+  if (status === 401 || status === 403) return true;
+
+  const normalizedType = contentType?.toLowerCase() ?? '';
+  const preview = body.slice(0, 5000).toLowerCase();
+  return normalizedType.includes('text/html') && (
+    preview.includes('fragmentafterlogin') ||
+    preview.includes('document.cookie') ||
+    preview.includes('accounts.sap.com') ||
+    preview.includes('/saml2/idp/sso')
+  );
+}

--- a/packages/notes/test/sap-notes-backend.unit.test.js
+++ b/packages/notes/test/sap-notes-backend.unit.test.js
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildSapNotesSearchParams,
+  extractSapNotePayload,
+  extractSapNotesBackendError,
+  isAuthenticationBootstrapResponse,
+  mapSapNotesSearchResponse,
+  parseODataDate
+} from '../dist/sap-notes-backend.js';
+
+test('buildSapNotesSearchParams escapes OData apostrophes and bounds the result count', () => {
+  const params = buildSapNotesSearchParams("kernel's patch", 2.9);
+
+  assert.equal(params.get('$top'), '2');
+  assert.equal(params.get('$inlinecount'), 'allpages');
+  assert.equal(params.get('$orderby'), 'Relevance desc');
+  assert.equal(params.get('$filter'), "FilterKeywordsFuzzy eq 'kernel''s patch'");
+  assert.equal(buildSapNotesSearchParams('query', 500).get('$top'), '100');
+});
+
+test('parseODataDate normalizes valid literals and rejects invalid values', () => {
+  assert.equal(parseODataDate('/Date(1427382729000)/'), '2015-03-26');
+  assert.equal(parseODataDate('2015-03-26'), null);
+  assert.equal(parseODataDate('/Date(not-a-number)/'), null);
+});
+
+test('mapSapNotesSearchResponse maps IDs, dates, counts, and site-relative URLs', () => {
+  const result = mapSapNotesSearchResponse({
+    d: {
+      __count: '341',
+      results: [{
+        Number: '0002137318',
+        Title: 'SYB: Start and stop database ASE with HADR',
+        Component: 'BC-DB-SYB',
+        ComponentName: 'SAP ASE Database',
+        ReleasedOn: '/Date(1427382729000)/',
+        URL: '/#/notes/0002137318'
+      }]
+    }
+  }, 'SYB ASE');
+
+  assert.deepEqual(result, {
+    query: 'SYB ASE',
+    totalResults: 341,
+    results: [{
+      id: '2137318',
+      title: 'SYB: Start and stop database ASE with HADR',
+      summary: 'SAP ASE Database',
+      language: 'EN',
+      releaseDate: '2015-03-26',
+      component: 'BC-DB-SYB',
+      url: 'https://me.sap.com/#/notes/0002137318'
+    }]
+  });
+});
+
+test('mapSapNotesSearchResponse rejects a malformed backend payload', () => {
+  assert.throws(
+    () => mapSapNotesSearchResponse({ d: {} }, 'query'),
+    /did not contain d\.results/
+  );
+});
+
+test('extractSapNotePayload reads the real Response.SAPNote shape', () => {
+  const sapNote = { Header: { Number: { value: '2744792' } } };
+  assert.equal(extractSapNotePayload({ Response: { SAPNote: sapNote } }), sapNote);
+  assert.equal(extractSapNotePayload({ SapNote: sapNote }), null);
+  assert.equal(extractSapNotePayload({ Response: { SAPNote: {} } }), null);
+});
+
+test('extractSapNotesBackendError reads structured Detail errors', () => {
+  assert.deepEqual(
+    extractSapNotesBackendError({
+      Response: {
+        Error: {
+          Code: 'DOES_NOT_EXIST',
+          Message: 'No document found with given parameter'
+        }
+      }
+    }),
+    {
+      code: 'DOES_NOT_EXIST',
+      message: 'No document found with given parameter'
+    }
+  );
+  assert.equal(extractSapNotesBackendError({ Response: { Error: {} } }), null);
+});
+
+test('isAuthenticationBootstrapResponse recognizes auth status and SAP HTML stubs', () => {
+  assert.equal(isAuthenticationBootstrapResponse(401, 'application/json', '{}'), true);
+  assert.equal(
+    isAuthenticationBootstrapResponse(200, 'text/html', '<script>fragmentAfterLogin = true</script>'),
+    true
+  );
+  assert.equal(isAuthenticationBootstrapResponse(200, 'application/json', '{}'), false);
+  assert.equal(isAuthenticationBootstrapResponse(500, 'text/html', '<h1>Backend error</h1>'), false);
+});


### PR DESCRIPTION
## Summary

- use a Playwright `APIRequestContext` initialized from the existing SAP storage state for authenticated SAP for Me backend requests
- make the SAP for Me OData endpoint the primary Notes search path and parse the real `Response.SAPNote` Detail shape
- recognize SAP's HTTP 200 login/bootstrap HTML as an expired session so the existing server-level auth retry performs a fresh login
- stop returning placeholder note content when an expired session produced an HTML bootstrap response
- keep the existing Coveo, browser, and legacy endpoints as non-auth fallbacks
- add focused tests for OData query escaping, mapping, date/URL normalization, structured Detail errors, and auth bootstrap detection

Fixes #30.

This is an independent implementation based on current `main`. PR #31 was useful evidence, but this patch does not build on it.

## Root cause

Current `main` is not universally broken: a cold username/password login followed by serialized Playwright state reload successfully searched and fetched a note in live testing. The reproducible failure is stale-session recovery:

1. cached cookies can be accepted locally based on their age even after SAP no longer accepts the server-side session
2. native Node `fetch` to the SAP for Me backend returns a small HTTP 200 HTML login/bootstrap document, even with cookies that work in a Playwright browser/request context
3. the raw Detail parser treated that HTML as a successfully located note and returned placeholder content
4. because the request appeared successful, `SESSION_EXPIRED` never reached `withAuthRetry`, so authentication was not invalidated and refreshed
5. the JSON parser also did not consume the current Detail response shape, `Response.SAPNote`

The issue's proposed session-storage explanation is not required by current SAP behavior: fresh Playwright `storageState` reloads worked, including a cookies-only state. The important distinction is the request implementation and correct recognition of SAP's auth bootstrap response.

Playwright officially supports initializing an isolated API request context from storage state:
https://playwright.dev/docs/api/class-apirequest

## Design choice

I evaluated native `fetch`, a kept-alive browser session similar to #31, page-context `fetch`, browser-context requests, and a standalone Playwright API request context.

The standalone API request context was selected because it:

- returns the authenticated JSON from both the OData search and Detail endpoints
- reuses the auth package's persisted session without launching or retaining a browser
- is single-flight initialized, maintains its cookie jar, and is disposed on session invalidation/shutdown
- works for both stdio and HTTP servers through the shared `SapNotesApiClient`
- avoids a second login, live-browser races, and separate invalidation state

## Validation

Live checks used configured SAP credentials without logging or committing secrets.

- cold password login from empty temporary cache/state: search and full Detail fetch passed
- forced stale/invalid session: first request emitted `SESSION_EXPIRED`; auth was invalidated; password login refreshed the state; retry returned the full note and OData search results
- direct backend sequence: note-ID search, keyword search, then Detail all returned authenticated JSON
- unit tests: 7/7 passed
- full-flow integration tests: 5/5 passed
- stdio MCP: initialize, list tools, live `search`, and live `fetch` passed
- Streamable HTTP MCP: list tools, live `search`, and live `fetch` passed
- repository `npm run build` passed
- repository `npm run typecheck` passed
- `git diff --check` passed