### PR TITLE
docs(repo): clarify dotenv secret quoting

### DIFF
--- a/packages/api-hub/README.md
+++ b/packages/api-hub/README.md
@@ -47,15 +47,17 @@ Fill the scaffolded `.env`:
 ```env
 AUTH_METHOD=auto
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 HEADFUL=false
 ```
+
+When using a `.env` file, quote any value containing `#`; dotenv otherwise treats `#` and everything after it as a comment. For example, use `SAP_PASSWORD="My#Pass"`. The same applies to `PFX_PASSPHRASE`.
 
 Optional SAP Passport/PFX fallback:
 
 ```env
 PFX_PATH=/absolute/path/to/sap-passport.pfx
-PFX_PASSPHRASE=your-passphrase
+PFX_PASSPHRASE="your-passphrase"
 ```
 
 `AUTH_METHOD=auto` chooses auth in this order:

--- a/packages/api-hub/env.example
+++ b/packages/api-hub/env.example
@@ -4,12 +4,14 @@
 # then fall back to PFX_PATH + PFX_PASSPHRASE if password auth is not configured.
 AUTH_METHOD=auto
 
+# dotenv treats # as the start of a comment in unquoted values.
+# Quote secrets that contain #, for example: SAP_PASSWORD="My#Pass"
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 
 # Optional SAP Passport / client certificate auth fallback.
 # PFX_PATH=/absolute/path/to/sap-passport.pfx
-# PFX_PASSPHRASE=
+# PFX_PASSPHRASE="your_certificate_passphrase"
 
 # Default is headless browser login. Set HEADFUL=true only when MFA or manual login is required.
 HEADFUL=false

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -154,6 +154,8 @@ const config = loadAuthConfigFromEnv({
 | `SAP_SSO_STORAGE_STATE` | Path to the shared SSO storage-state file |
 | `PLAYWRIGHT_BROWSER_TYPE` | `chromium` (default) \| `firefox` \| `webkit` |
 
+When loading configuration from a `.env` file, quote any value containing `#`; dotenv otherwise treats `#` and everything after it as a comment. For example, use `SAP_PASSWORD="My#Pass"`. The same applies to `PFX_PASSPHRASE`.
+
 ### Also exported
 
 `isOnAuthPage`, `isAuthUrl`, `selectCookies`, `serializeCookies`, `defaultLogger`, and the error classes `AuthenticationError`, `CertificateLoadError`, `AuthenticationTimeoutError`, `BrowserNotFoundError`. The `Logger` interface lets you inject your own logger (`{ warn, error, info, debug }`); a stderr `defaultLogger` is used otherwise.

--- a/packages/notes/README.md
+++ b/packages/notes/README.md
@@ -62,8 +62,10 @@ The simplest approach — no certificate management required.
 
 ```env
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 ```
+
+When using a `.env` file, quote any value containing `#`; dotenv otherwise treats `#` and everything after it as a comment. For example, use `SAP_PASSWORD="My#Pass"`. The same applies to `PFX_PASSPHRASE`.
 
 Or pass credentials directly in your MCP client config (no `.env` file needed):
 
@@ -95,7 +97,7 @@ Uses a `.pfx` client certificate for TLS-level authentication.
 3. Configure:
    ```env
    PFX_PATH=./certs/sap.pfx
-   PFX_PASSPHRASE=your_certificate_passphrase
+   PFX_PASSPHRASE="your_certificate_passphrase"
    ```
 
 ### Auto Mode (Default)

--- a/packages/notes/env.example
+++ b/packages/notes/env.example
@@ -1,12 +1,14 @@
 # ─── Authentication (choose one method) ─────────────────────────
 
 # Option 1: Username/Password (recommended — easiest to set up)
+# dotenv treats # as the start of a comment in unquoted values.
+# Quote secrets that contain #, for example: SAP_PASSWORD="My#Pass"
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 
 # Option 2: SAP Passport Certificate
 # PFX_PATH=./certs/sap.pfx
-# PFX_PASSPHRASE=your_certificate_passphrase_here
+# PFX_PASSPHRASE="your_certificate_passphrase_here"
 
 # Auth method selection: 'auto' (default), 'password', or 'certificate'
 # auto = tries password first if credentials are set, then certificate

--- a/packages/roadmap/README.md
+++ b/packages/roadmap/README.md
@@ -44,15 +44,17 @@ Fill the scaffolded `.env`:
 ```env
 AUTH_METHOD=auto
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 HEADFUL=false
 ```
+
+When using a `.env` file, quote any value containing `#`; dotenv otherwise treats `#` and everything after it as a comment. For example, use `SAP_PASSWORD="My#Pass"`. The same applies to `PFX_PASSPHRASE`.
 
 Optional SAP Passport/PFX fallback:
 
 ```env
 PFX_PATH=/absolute/path/to/sap-passport.pfx
-PFX_PASSPHRASE=your-passphrase
+PFX_PASSPHRASE="your-passphrase"
 ```
 
 `AUTH_METHOD=auto` chooses auth in this order:

--- a/packages/roadmap/env.example
+++ b/packages/roadmap/env.example
@@ -4,12 +4,14 @@
 # then fall back to PFX_PATH + PFX_PASSPHRASE if password auth is not configured.
 AUTH_METHOD=auto
 
+# dotenv treats # as the start of a comment in unquoted values.
+# Quote secrets that contain #, for example: SAP_PASSWORD="My#Pass"
 SAP_USERNAME=your.email@company.com
-SAP_PASSWORD=your_sap_password
+SAP_PASSWORD="your_sap_password"
 
 # Optional SAP Passport / client certificate auth fallback.
 # PFX_PATH=/absolute/path/to/sap-passport.pfx
-# PFX_PASSPHRASE=
+# PFX_PASSPHRASE="your_certificate_passphrase"
 
 # Default is headless browser login. Set HEADFUL=true only when MFA or manual login is required.
 HEADFUL=false


### PR DESCRIPTION
## Goal

Prevent misleading SAP authentication failures when credentials or certificate passphrases contain `#` in dotenv-backed configuration.

## Changes

- document that dotenv treats `#` as the start of a comment in unquoted values
- demonstrate quoting with `SAP_PASSWORD="My#Pass"`
- quote password and PFX passphrase placeholders in the API Hub, Roadmap, and Notes README examples
- apply the same guidance to all three shipped `env.example` files and the shared auth README

This follows the configuration correction reported in #30. The separate SAP Passport/Playwright runtime problem remains tracked in #38.

## Impact

Documentation only. Users copying the examples get safe defaults, and users with `#` in `SAP_PASSWORD` or `PFX_PASSPHRASE` get an explicit explanation instead of an apparent login or MFA hang.

## Validation

- `git diff --check`
- direct dotenv parser check confirming:
  - `SAP_PASSWORD=My#Pass` parses as `My`
  - `SAP_PASSWORD="My#Pass"` preserves the complete value
- final diff reviewed after rebasing onto the latest `main`

Build and live SAP tests were not run because this PR changes documentation and examples only.