### PR TITLE
fix(notes): add required CorrIns paging and TCI package URL

### DIFF
--- a/packages/notes/README.md
+++ b/packages/notes/README.md
@@ -6,7 +6,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.12.0-brightgreen.svg)](https://nodejs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-7.0-blue.svg)](https://www.typescriptlang.org/)
 
 [![Add to Werkbank][werkbank-badge]][werkbank-install]
 

--- a/packages/notes/docs/tools.md
+++ b/packages/notes/docs/tools.md
@@ -138,7 +138,16 @@ Fetch the complete content and metadata for a specific SAP Note by ID. Returns f
       noteNumber: string;
       title: string;
     }>;
+    downloadUrl?: string;         // TCI only: transport package on softwaredownloads.sap.com
   }>;
+
+**Correction instructions vs. TCI.** Each entry in `correctionDetails` is one correction instruction,
+bound to a software component and a release range (e.g. `SAP_BASIS 700-700`) — a note with 11 corrections
+returns 11 entries, typically one per release. `downloadUrl` is populated **only** for
+Transport-Based Correction Instructions (TCI) and points at the transport package; it is absent for
+classic correction instructions, so it is a reliable way to tell the two apart without parsing note text.
+The package itself is behind SAP SSO and must be downloaded interactively — the URL is provided for
+navigation, not for automated fetching.
 }
 ```
 

--- a/packages/notes/docs/tools.md
+++ b/packages/notes/docs/tools.md
@@ -138,7 +138,7 @@ Fetch the complete content and metadata for a specific SAP Note by ID. Returns f
       noteNumber: string;
       title: string;
     }>;
-    downloadUrl?: string;         // TCI only: transport package on softwaredownloads.sap.com
+    downloadUrl?: string;             // TCI only: HTTPS transport package URL
   }>;
 
 **Correction instructions vs. TCI.** Each entry in `correctionDetails` is one correction instruction,
@@ -146,8 +146,8 @@ bound to a software component and a release range (e.g. `SAP_BASIS 700-700`) —
 returns 11 entries, typically one per release. `downloadUrl` is populated **only** for
 Transport-Based Correction Instructions (TCI) and points at the transport package; it is absent for
 classic correction instructions, so it is a reliable way to tell the two apart without parsing note text.
-The package itself is behind SAP SSO and must be downloaded interactively — the URL is provided for
-navigation, not for automated fetching.
+The package itself is behind SAP SSO and must be downloaded interactively — the validated HTTPS URL
+is provided for navigation, not for automated fetching.
 }
 ```
 

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -21,6 +21,7 @@ import {
 
 const CORRINS_PATH =
   '/backend/raw/core/W7LegacyProxyVerticle/odata/svt/snogwscorrins/CorrInsSet';
+const CORRINS_PAGE_SIZE = 100;
 
 type CorrInsNavigationProperty = 'TADIR' | 'Prerequisite';
 
@@ -70,6 +71,17 @@ export interface SapNoteCorrectionSummary {
   softwareComponent: string;
   pakId: string;
   count?: number;
+}
+
+export interface SapNoteCorrectionDetail {
+  softwareComponent: string;
+  versionFrom: string;
+  versionTo: string;
+  sapNotesNumber: string;
+  sapNotesTitle: string;
+  objects?: Array<{ objectName: string; objectType: string }>;
+  prerequisites?: Array<{ noteNumber: string; title: string }>;
+  downloadUrl?: string;
 }
 
 export interface SapNoteDetail {
@@ -574,10 +586,10 @@ export class SapNotesApiClient {
     noteId: string,
     correctionsSummary: SapNoteCorrectionSummary[],
     token: string
-  ): Promise<any[]> {
+  ): Promise<SapNoteCorrectionDetail[]> {
     logger.info(`🔧 Fetching correction details for note ${noteId} (${correctionsSummary.length} components)`);
 
-    const allCorrections: any[] = [];
+    const allCorrections: SapNoteCorrectionDetail[] = [];
     const paddedNoteId = noteId.padStart(10, '0');
 
     for (const summary of correctionsSummary) {
@@ -597,27 +609,29 @@ export class SapNotesApiClient {
 
         // For each correction instruction, fetch TADIR (objects) and Prerequisites
         for (const entry of corrInsEntries) {
-          const correction: any = {
-            softwareComponent: entry.Name || summary.softwareComponent,
-            versionFrom: entry.VerFrom || '',
-            versionTo: entry.VerTo || '',
-            sapNotesNumber: entry.SapNotesNumber || noteId,
-            sapNotesTitle: entry.SapNotesTitle || '',
+          const correction: SapNoteCorrectionDetail = {
+            softwareComponent: this.stringField(entry, 'Name') ?? summary.softwareComponent,
+            versionFrom: this.stringField(entry, 'VerFrom') ?? '',
+            versionTo: this.stringField(entry, 'VerTo') ?? '',
+            sapNotesNumber: this.stringField(entry, 'SapNotesNumber') ?? noteId,
+            sapNotesTitle: this.stringField(entry, 'SapNotesTitle') ?? '',
           };
 
           // Populated only for Transport-Based Correction Instructions (TCI): the transport
           // package on softwaredownloads.sap.com. Absent for classic correction instructions,
           // so it doubles as a structural TCI indicator.
-          if (entry.DownloadURL) correction.downloadUrl = entry.DownloadURL;
+          const downloadUrl = this.httpsUrlField(entry, 'DownloadURL');
+          if (downloadUrl) correction.downloadUrl = downloadUrl;
 
           // Fetch TADIR (affected objects) — optional, may fail
           try {
             const tadirEntries = await this.fetchCorrInsNavigation(entry, 'TADIR', token);
             if (tadirEntries && tadirEntries.length > 0) {
-              correction.objects = tadirEntries.map((t: any) => ({
-                objectName: t.ObjName || '',
-                objectType: t.ObjType || '',
+              const objects = tadirEntries.map((t: any) => ({
+                objectName: this.stringField(t, 'ObjName') ?? '',
+                objectType: this.stringField(t, 'ObjType') ?? '',
               })).filter((o: any) => o.objectName);
+              if (objects.length) correction.objects = objects;
             }
           } catch (tadirErr) {
             if (isSessionExpiredError(tadirErr)) throw tadirErr;
@@ -628,10 +642,9 @@ export class SapNotesApiClient {
           try {
             const preEntries = await this.fetchCorrInsNavigation(entry, 'Prerequisite', token);
             if (preEntries && preEntries.length > 0) {
-              correction.prerequisites = preEntries.map((p: any) => ({
-                noteNumber: p.SapNotesNumber || '',
-                title: p.Title || '',
-              })).filter((p: any) => p.noteNumber);
+              const prerequisites = this.mapUniqueReferences(preEntries)
+                .map(({ noteNumber, title }) => ({ noteNumber, title }));
+              if (prerequisites.length) correction.prerequisites = prerequisites;
             }
           } catch (preErr) {
             if (isSessionExpiredError(preErr)) throw preErr;
@@ -651,16 +664,56 @@ export class SapNotesApiClient {
   }
 
   /**
+   * Fetch every page from a CorrIns OData collection.
+   *
+   * The W7LegacyProxy returns an empty collection unless `$top` is present, so every request uses
+   * the paging shape sent by SAP for Me. Continue until the advertised count or a short page is
+   * reached instead of silently truncating notes or navigation collections above 100 rows.
+   */
+  private async fetchCorrInsCollection(
+    path: string,
+    token: string,
+    params: Record<string, string> = {}
+  ): Promise<any[]> {
+    const results: any[] = [];
+    let skip = 0;
+
+    while (true) {
+      const json: any = await this.fetchBackendJson(path, token, {
+        ...params,
+        $skip: String(skip),
+        $top: String(CORRINS_PAGE_SIZE),
+        $inlinecount: 'allpages'
+      });
+      const page = json?.d?.results;
+
+      if (!Array.isArray(page)) {
+        if (skip === 0 && json?.d && typeof json.d === 'object') return [json.d];
+        return results;
+      }
+
+      results.push(...page);
+      const rawCount = json?.d?.__count;
+      const parsedTotal = /^\d+$/.test(String(rawCount ?? '')) ? Number(rawCount) : undefined;
+      const total = Number.isSafeInteger(parsedTotal) ? parsedTotal : undefined;
+      if (page.length < CORRINS_PAGE_SIZE || (total !== undefined && results.length >= total)) {
+        return total !== undefined ? results.slice(0, total) : results;
+      }
+      if (total === undefined) {
+        throw new Error('CorrIns response omitted a valid __count for a full page');
+      }
+
+      skip += page.length;
+    }
+  }
+
+  /**
    * Fetch CorrInsSet entries for a note + software component from the OData service.
    */
   private async fetchCorrInsSet(paddedNoteId: string, pakId: string, token: string): Promise<any[]> {
-    const json: any = await this.fetchBackendJson(CORRINS_PATH, token, {
-      $skip: '0',
-      $top: '100',
-      $filter: `SapNotesNumber eq '${escapeODataString(paddedNoteId)}' and PakId eq '${escapeODataString(pakId)}'`,
-      $inlinecount: 'allpages'
+    return this.fetchCorrInsCollection(CORRINS_PATH, token, {
+      $filter: `SapNotesNumber eq '${escapeODataString(paddedNoteId)}' and PakId eq '${escapeODataString(pakId)}'`
     });
-    return Array.isArray(json?.d?.results) ? json.d.results : [];
   }
 
   /**
@@ -681,14 +734,10 @@ export class SapNotesApiClient {
       `VerTo='${escapeODataString(entry.VerTo)}'`,
     ].join(',');
 
-    const json: any = await this.fetchBackendJson(
+    return this.fetchCorrInsCollection(
       `${CORRINS_PATH}(${keyParts})/${navProperty}`,
-      token,
-      { $skip: '0', $top: '100', $inlinecount: 'allpages' }
+      token
     );
-    if (Array.isArray(json?.d?.results)) return json.d.results;
-    if (json?.d && typeof json.d === 'object') return [json.d];
-    return [];
   }
 
   /**
@@ -1687,6 +1736,18 @@ export class SapNotesApiClient {
     return undefined;
   }
 
+  /** Read a normalized HTTPS URL, rejecting non-web or malformed values. */
+  private httpsUrlField(item: any, ...names: string[]): string | undefined {
+    const value = this.stringField(item, ...names);
+    if (!value) return undefined;
+    try {
+      const url = new URL(value);
+      return url.protocol === 'https:' ? url.toString() : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   /** Read a non-negative integer without accepting partially numeric strings. */
   private integerField(item: any, ...names: string[]): number | undefined {
     const value = this.itemField(item, ...names);
@@ -1701,7 +1762,7 @@ export class SapNotesApiClient {
   /** Map a reference-style item (References.RefTo/RefBy, Preconditions, SideEffects). */
   private mapReference(item: any): SapNoteReference {
     return {
-      noteNumber: this.stringField(item, 'RefNumber', 'SAPNoteNumber', 'Number') ?? '',
+      noteNumber: this.stringField(item, 'RefNumber', 'SAPNoteNumber', 'SapNotesNumber', 'Number') ?? '',
       title: this.stringField(item, 'RefTitle', 'Title') ?? '',
       noteType: this.stringField(item, 'RefComponent', 'Component', 'Type')
     };

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -605,6 +605,11 @@ export class SapNotesApiClient {
             sapNotesTitle: entry.SapNotesTitle || '',
           };
 
+          // Populated only for Transport-Based Correction Instructions (TCI): the transport
+          // package on softwaredownloads.sap.com. Absent for classic correction instructions,
+          // so it doubles as a structural TCI indicator.
+          if (entry.DownloadURL) correction.downloadUrl = entry.DownloadURL;
+
           // Fetch TADIR (affected objects) — optional, may fail
           try {
             const tadirEntries = await this.fetchCorrInsNavigation(entry, 'TADIR', token);
@@ -650,8 +655,10 @@ export class SapNotesApiClient {
    */
   private async fetchCorrInsSet(paddedNoteId: string, pakId: string, token: string): Promise<any[]> {
     const json: any = await this.fetchBackendJson(CORRINS_PATH, token, {
+      $skip: '0',
+      $top: '100',
       $filter: `SapNotesNumber eq '${escapeODataString(paddedNoteId)}' and PakId eq '${escapeODataString(pakId)}'`,
-      $format: 'json'
+      $inlinecount: 'allpages'
     });
     return Array.isArray(json?.d?.results) ? json.d.results : [];
   }
@@ -677,7 +684,7 @@ export class SapNotesApiClient {
     const json: any = await this.fetchBackendJson(
       `${CORRINS_PATH}(${keyParts})/${navProperty}`,
       token,
-      { $format: 'json' }
+      { $skip: '0', $top: '100', $inlinecount: 'allpages' }
     );
     if (Array.isArray(json?.d?.results)) return json.d.results;
     if (json?.d && typeof json.d === 'object') return [json.d];

--- a/packages/notes/src/schemas/sap-notes.ts
+++ b/packages/notes/src/schemas/sap-notes.ts
@@ -265,10 +265,10 @@ export const NoteGetOutputSchema = {
         noteNumber: z.string(),
         title: z.string(),
       })).optional(),
-      downloadUrl: z.string().optional(),
+      downloadUrl: z.string().url().optional(),
     }))
     .optional()
-    .describe('Detailed correction instructions (only when includeCorrections=true). Lists affected ABAP objects and per-correction prerequisites.'),
+    .describe('Detailed correction instructions (only when includeCorrections=true). Lists affected ABAP objects, per-correction prerequisites, and an HTTPS transport-package URL for TCI entries.'),
 
   manualActions: z
     .string()

--- a/packages/notes/src/schemas/sap-notes.ts
+++ b/packages/notes/src/schemas/sap-notes.ts
@@ -265,6 +265,7 @@ export const NoteGetOutputSchema = {
         noteNumber: z.string(),
         title: z.string(),
       })).optional(),
+      downloadUrl: z.string().optional(),
     }))
     .optional()
     .describe('Detailed correction instructions (only when includeCorrections=true). Lists affected ABAP objects and per-correction prerequisites.'),

--- a/packages/notes/test/sap-notes-api.unit.test.js
+++ b/packages/notes/test/sap-notes-api.unit.test.js
@@ -179,6 +179,93 @@ test('CorrIns requests use the authenticated backend context and escape OData st
   assert.match(calls[1].path, /Name='O''Hare'/);
   assert.equal(calls[0].token, 'sap-token');
   assert.equal(calls[1].token, 'sap-token');
+  for (const call of calls) {
+    assert.equal(call.params.$skip, '0');
+    assert.equal(call.params.$top, '100');
+    assert.equal(call.params.$inlinecount, 'allpages');
+    assert.equal('$format' in call.params, false);
+  }
+});
+
+test('CorrIns requests retrieve every advertised OData page', async () => {
+  const client = createClient();
+  const calls = [];
+  client.fetchBackendJson = async (_path, _token, params) => {
+    calls.push(params);
+    const skip = Number(params.$skip);
+    const length = skip === 0 ? 100 : 1;
+    return {
+      d: {
+        __count: '101',
+        results: Array.from({ length }, (_, index) => ({ Aleid: String(skip + index) }))
+      }
+    };
+  };
+
+  const rows = await client.fetchCorrInsSet('0003096734', '41', 'sap-token');
+
+  assert.equal(rows.length, 101);
+  assert.equal(rows[100].Aleid, '100');
+  assert.deepEqual(calls.map(call => call.$skip), ['0', '100']);
+  assert.ok(calls.every(call => call.$top === '100'));
+  assert.ok(calls.every(call => !('$format' in call)));
+});
+
+test('CorrIns paging rejects a full page without a valid advertised count', async () => {
+  const client = createClient();
+  client.fetchBackendJson = async () => ({
+    d: {
+      __count: 'not-a-number',
+      results: Array.from({ length: 100 }, (_, index) => ({ Aleid: String(index) }))
+    }
+  });
+
+  await assert.rejects(
+    client.fetchCorrInsSet('0003096734', '41', 'sap-token'),
+    /omitted a valid __count/
+  );
+});
+
+test('correction details normalize TCI URLs and reject non-HTTPS values', async () => {
+  const client = createClient();
+  client.fetchCorrInsSet = async () => [{
+    Name: ' S4CORE ',
+    VerFrom: 106,
+    VerTo: 106,
+    SapNotesNumber: ' 0003195213 ',
+    SapNotesTitle: ' TCI fixture ',
+    DownloadURL: ' https://softwaredownloads.sap.com/file.SAR '
+  }, {
+    Name: 'S4CORE',
+    VerFrom: '107',
+    VerTo: '107',
+    SapNotesNumber: '0003195213',
+    SapNotesTitle: 'Unsafe fixture',
+    DownloadURL: 'javascript:alert(1)'
+  }];
+  client.fetchCorrInsNavigation = async () => [];
+
+  const corrections = await client.getCorrectionDetails(
+    '3195213',
+    [{ softwareComponent: 'S4CORE', pakId: '19773' }],
+    'sap-token'
+  );
+
+  assert.deepEqual(corrections, [{
+    softwareComponent: 'S4CORE',
+    versionFrom: '106',
+    versionTo: '106',
+    sapNotesNumber: '0003195213',
+    sapNotesTitle: 'TCI fixture',
+    downloadUrl: 'https://softwaredownloads.sap.com/file.SAR'
+  }, {
+    softwareComponent: 'S4CORE',
+    versionFrom: '107',
+    versionTo: '107',
+    sapNotesNumber: '0003195213',
+    sapNotesTitle: 'Unsafe fixture'
+  }]);
+  assert.deepEqual(NoteGetOutputSchema.correctionDetails.parse(corrections), corrections);
 });
 
 test('correction-detail lookup propagates session expiry for the auth retry', async () => {


### PR DESCRIPTION
Follow-up to #43. Thanks to @adam0thman for tracing the CorrIns endpoint and identifying the TCI metadata.

## Root cause

A fresh authenticated session and an isolated request matrix showed that the W7LegacyProxy requires `$top` for this collection. `$format=json` is not the cause of the empty result:

| Query shape for note 3096734 / PakId 41 | Rows | Inline count |
|---|---:|---:|
| filter only | 0 | — |
| filter + `$skip=0` | 0 | — |
| filter + `$inlinecount=allpages` | 0 | 11 |
| filter + `$top=100` | 11 | — |
| full UI paging shape | 11 | 11 |
| full UI paging shape + `$format=json` | 11 | 11 |

The implementation now consistently sends `$skip`, `$top`, and `$inlinecount` for both the CorrIns collection and navigation properties. It also retrieves all advertised pages instead of silently truncating at 100 rows, and rejects an invalid missing count on a full page rather than risking unbounded paging.

## TCI metadata and response hardening

- Exposes `DownloadURL` as `correctionDetails[].downloadUrl`.
- Trims and validates that package URLs are well-formed HTTPS URLs before returning them.
- Adds URL validation to the MCP output schema.
- Normalizes correction and TADIR fields and omits empty object lists.
- Reuses normalized, deduplicated reference mapping for prerequisites.
- Documents the CI/TCI distinction and updates the stale TypeScript version badge.

`downloadUrl` remains absent for classic correction instructions, so its presence provides a structural TCI indicator without parsing note text. Package download still requires SAP authentication.

## Live verification

Using a fresh, isolated SAP SSO state:

- Note 3096734: 11 correction entries and 11 affected objects across SAP_BASIS releases; no TCI URL.
- Note 3195213: one S4CORE 106 correction, one affected object, and a validated `softwaredownloads.sap.com` HTTPS package URL.
- `test:auth`, `test:api`, and the full MCP handshake/tool protocol test all pass.

## Automated verification

- `npm run test:unit -w sap-note-search-mcp`: 15/15 pass.
- `npm run build`: pass for all workspaces.
- `npm run typecheck`: pass for all workspaces.
- `git diff --check`: pass.

The unit suite uses the Node test runner and is fully verified on this branch; no Vitest dependency is involved.