### PR TITLE
feat(notes): add fetch_attachment tool to download SAP Note attachments

### DIFF
--- a/packages/notes/docs/tools.md
+++ b/packages/notes/docs/tools.md
@@ -168,6 +168,60 @@ SAP Note content typically includes these sections:
 
 ---
 
+## `fetch_attachment`
+
+Downloads a file attached to an SAP Note and saves it to disk.
+
+### Input
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `url` | string (URL) | yes | Attachment URL taken **verbatim** from the `attachments` array of `fetch()`. These URLs are opaque — do not construct them. |
+| `outputDir` | string | no | Directory to write into. Defaults to the OS temp directory; must already exist. |
+| `filename` | string | no | Name to save as. Defaults to the attachment's filename. Path separators are stripped. |
+
+### Output
+
+| Field | Type | Description |
+|---|---|---|
+| `path` | string | Absolute path of the saved file |
+| `filename` | string | Name it was saved as |
+| `contentType` | string | Content-Type reported by SAP |
+| `bytes` | number | Size on disk |
+| `sha256` | string | SHA-256 of the bytes |
+
+### Notes
+
+Attachments are served from SAP's support document hosts — observed:
+`documents.support.sap.com` and `userapps.support.sap.com`. Both are needed; several
+notes use one and several use the other. Downloads are restricted to an allowlist of
+SAP hosts so the tool cannot be used as a general-purpose fetcher.
+
+**Authentication differs from the JSON backend.** The me.sap.com storage state alone is
+not sufficient for the document hosts. Where `PFX_PATH` is configured the client
+certificate is presented for those origins, which is what authenticates them; session
+cookies are still supplied so cookie-authenticated hosts keep working.
+
+**An unauthenticated request answers `HTTP 200` with a ~1.8 KB HTML login stub**, not an
+error status. Saving that blindly would produce a file named `something.png` containing
+JavaScript. The tool checks the content type and rejects the stub, so a successful result
+means real bytes.
+
+### Example
+
+```
+fetch(id="2187425")
+  → attachments: [{ filename: "TCI_for_Customer.pdf", url: "https://userapps.support.sap.com/..." }]
+
+fetch_attachment(url="https://userapps.support.sap.com/...", outputDir="/tmp")
+  → { path: "/tmp/TCI_for_Customer.pdf", contentType: "application/pdf",
+      bytes: 878422, sha256: "6f64e07c7903..." }
+```
+
+Verified live against 10 notes carrying attachments, yielding `image/png`,
+`application/pdf`, `application/vnd.ms-excel`, `application/x-zip-compressed` and
+`application/x-tika-msoffice` across both hosts.
+
 ## Recommended Workflow
 
 For best results, chain search and fetch:

--- a/packages/notes/scripts/test-attachments.mjs
+++ b/packages/notes/scripts/test-attachments.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Live check for fetch_attachment.
+ *
+ * Scans candidate SAP Notes for an "Attachments" section, then downloads one
+ * attachment from each of the first N notes that have any, verifying that real
+ * bytes come back rather than the HTML login stub.
+ *
+ *   node scripts/test-attachments.mjs [targetNoteCount]
+ */
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createHash } from 'crypto';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: resolve(__dirname, '..', '.env') });
+
+const { SapNotesApiClient } = await import('../dist/sap-notes-api.js');
+const { createNotesAuthenticator } = await import('../dist/auth.js');
+
+const TARGET = Number(process.argv[2] || 10);
+
+// Candidate notes drawn from several components so the sample is not all KBAs
+// of one kind. Attachment presence is discovered, not assumed.
+const CANDIDATES = [
+  '3137004', '2388483', '1587566', '3606053', '2311166', '2075073', '1749142',
+  '1897372', '2098954', '2501703', '2309060', '3191095', '1705730', '3570638',
+  '1431751', '2370780', '2119087', '2399996', '3743709', '1984422', '2551720',
+  '2265085', '2544831', '2532380', '3504340', '2025528', '1746967', '1375378',
+  '2191612', '3467895', '3481355', '3439136', '2934135', '1872170', '2593571',
+  '2100040', '1969700', '1438410', '2222218', '1999997', '2000003', '2114710',
+  '2380176', '2600030', '1999993', '2154870', '3346306', '2187425', '2543372',
+  '2499947', '2576306', '2632375', '1856748', '2640978', '2489468', '40850',
+  '2509738', '1710320', '1869240', '1990193', '2098954', '16083', '2190119'
+];
+
+function magic(buf) {
+  const b = buf.subarray(0, 8);
+  if (b[0] === 0x89 && b[1] === 0x50) return 'PNG';
+  if (b[0] === 0xff && b[1] === 0xd8) return 'JPEG';
+  if (b.toString('utf8', 0, 4) === '%PDF') return 'PDF';
+  if (b[0] === 0x50 && b[1] === 0x4b) return 'ZIP/OOXML';
+  if (b.toString('utf8', 0, 5).toLowerCase().includes('<html')) return 'HTML(!)';
+  if (b.toString('utf8', 0, 6) === 'GIF89a' || b.toString('utf8', 0, 6) === 'GIF87a') return 'GIF';
+  return 'other';
+}
+
+const cfg = {
+  sapUsername: process.env.SAP_USERNAME,
+  sapPassword: process.env.SAP_PASSWORD,
+  authMethod: process.env.AUTH_METHOD,
+  pfxPath: process.env.PFX_PATH,
+  pfxPassphrase: process.env.PFX_PASSPHRASE,
+  headless: true
+};
+
+const auth = createNotesAuthenticator(cfg);
+const client = new SapNotesApiClient(cfg);
+const { cookieHeader: token } = await auth.ensureSession();
+
+const outDir = mkdtempSync(join(tmpdir(), 'sapatt-'));
+console.log(`output dir: ${outDir}\n`);
+
+// Attachments are not common, so widen the pool with search hits when the
+// seed list is exhausted. Queries chosen to surface screenshot-heavy KBAs.
+const SEARCH_QUERIES = [
+  'how to configure step by step screenshot',
+  'SAP GUI installation error screenshot',
+  'transaction configuration guide',
+  'troubleshooting guide error message',
+  'how to download install package',
+  'security audit log configuration',
+  'HANA cockpit configuration',
+  'Fiori launchpad setup',
+  'transport management configuration',
+  'user authorization trace analysis'
+];
+
+async function candidateIds() {
+  const seen = new Set();
+  const ids = [];
+  for (const id of CANDIDATES) { if (!seen.has(id)) { seen.add(id); ids.push(id); } }
+  for (const q of SEARCH_QUERIES) {
+    try {
+      const r = await client.searchNotes(q, token, 10);
+      for (const n of r.results ?? []) {
+        if (n.id && !seen.has(n.id)) { seen.add(n.id); ids.push(n.id); }
+      }
+    } catch { /* search failure just means fewer candidates */ }
+  }
+  return ids;
+}
+
+const withAttachments = [];
+const pool = await candidateIds();
+console.log(`scanning up to ${pool.length} notes for an Attachments section…\n`);
+
+let scanned = 0;
+for (const id of pool) {
+  if (withAttachments.length >= TARGET) break;
+  scanned++;
+  await new Promise(r => setTimeout(r, 600)); // be polite: the Detail endpoint rate-limits
+  try {
+    const note = await client.getNote(id, token);
+    const atts = note?.attachments ?? [];
+    if (atts.length) {
+      withAttachments.push({ id, title: (note.title || '').slice(0, 58), atts });
+      console.log(`  ✓ ${id}  ${String(atts.length).padStart(3)} attachment(s)  ${(note.title || '').slice(0, 52)}`);
+    }
+  } catch (e) {
+    // a note we cannot read is not a test failure — just skip it
+  }
+}
+console.log(`\n(scanned ${scanned} notes)`);
+
+console.log(`\nfound ${withAttachments.length} notes with attachments\n`);
+console.log('downloading one attachment from each…\n');
+
+let pass = 0, fail = 0;
+const results = [];
+
+for (const { id, atts } of withAttachments) {
+  const a = atts[0];
+  try {
+    const { body, contentType, bytes } = await client.fetchAttachment(a.url, token);
+    const sha = createHash('sha256').update(body).digest('hex');
+    const kind = magic(body);
+    const ok = kind !== 'HTML(!)' && bytes > 0;
+    ok ? pass++ : fail++;
+    results.push({ id, name: a.filename, contentType, bytes, kind, sha: sha.slice(0, 12), ok });
+    console.log(
+      `  ${ok ? '✓' : '✗'} note ${id.padEnd(8)} ${String(bytes).padStart(9)} B  ` +
+      `${contentType.padEnd(26)} ${kind.padEnd(10)} ${sha.slice(0, 12)}  ${(a.filename || '').slice(0, 24)}`
+    );
+  } catch (e) {
+    fail++;
+    results.push({ id, name: a.filename, error: String(e.message || e).slice(0, 90), ok: false });
+    console.log(`  ✗ note ${id.padEnd(8)} ERROR  ${String(e.message || e).slice(0, 90)}`);
+  }
+}
+
+console.log('\n── guard checks ──');
+for (const [label, url] of [
+  ['non-SAP host rejected     ', 'https://example.com/evil.png'],
+  ['http (not https) rejected ', 'http://documents.support.sap.com/customerkba/x'],
+  ['malformed URL rejected    ', 'not-a-url']
+]) {
+  try {
+    await client.fetchAttachment(url, token);
+    console.log(`  ✗ ${label} — NOT rejected`);
+    fail++;
+  } catch (e) {
+    console.log(`  ✓ ${label} — ${String(e.message).slice(0, 62)}`);
+    pass++;
+  }
+}
+
+const hosts = [...new Set(withAttachments.map(w => { try { return new URL(w.atts[0].url).hostname; } catch { return '?'; } }))];
+console.log(`\nattachment hosts seen    : ${hosts.join(', ')}`);
+const types = [...new Set(results.filter(r => r.contentType).map(r => r.contentType))];
+console.log(`\n── summary ──`);
+console.log(`notes with attachments : ${withAttachments.length}`);
+console.log(`downloads passed       : ${pass}`);
+console.log(`downloads failed       : ${fail}`);
+console.log(`distinct content types : ${types.join(', ') || '(none)'}`);
+
+rmSync(outDir, { recursive: true, force: true });
+await auth.destroy?.().catch?.(() => {});
+process.exit(fail > 0 ? 1 : 0);

--- a/packages/notes/src/mcp-server.ts
+++ b/packages/notes/src/mcp-server.ts
@@ -3,6 +3,10 @@ import { config } from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join, isAbsolute, resolve } from 'path';
 import { existsSync, realpathSync } from 'fs';
+import { writeFile } from 'fs/promises';
+import { createHash } from 'crypto';
+import { tmpdir } from 'os';
+import { basename } from 'path';
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -17,7 +21,10 @@ import {
   NoteGetInputSchema,
   NoteGetOutputSchema,
   SAP_NOTE_SEARCH_DESCRIPTION,
-  SAP_NOTE_GET_DESCRIPTION
+  SAP_NOTE_GET_DESCRIPTION,
+  NoteAttachmentInputSchema,
+  NoteAttachmentOutputSchema,
+  SAP_NOTE_ATTACHMENT_DESCRIPTION
 } from './schemas/sap-notes.js';
 import { parseNoteContent } from './html-utils.js';
 
@@ -353,6 +360,66 @@ class SapNoteMcpServer {
             content: [{
               type: 'text',
               text: `Failed to retrieve SAP Note ${id}: ${errorMessage}`
+            }],
+            isError: true
+          };
+        }
+      }
+    );
+
+    this.mcpServer.registerTool(
+      'fetch_attachment',
+      {
+        title: 'Download SAP Note Attachment',
+        description: SAP_NOTE_ATTACHMENT_DESCRIPTION,
+        inputSchema: NoteAttachmentInputSchema,
+        outputSchema: NoteAttachmentOutputSchema
+      },
+      async ({ url, outputDir, filename }) => {
+        logger.info(`📎 [fetch_attachment] Downloading ${url}`);
+
+        try {
+          const { body, contentType, bytes } = await this.withAuthRetry(token =>
+            this.sapNotesClient.fetchAttachment(url, token)
+          );
+
+          // Never let a caller-supplied name escape the target directory.
+          const fallback = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'attachment');
+          const safeName = basename(filename?.trim() || fallback).replace(/[/\\]/g, '') || 'attachment';
+
+          const dir = outputDir?.trim() ? resolve(outputDir.trim()) : tmpdir();
+          if (!existsSync(dir)) {
+            throw new Error(`Output directory does not exist: ${dir}`);
+          }
+
+          const target = join(dir, safeName);
+          await writeFile(target, body);
+
+          const sha256 = createHash('sha256').update(body).digest('hex');
+          const output = { path: target, filename: safeName, contentType, bytes, sha256 };
+
+          logger.info(`✅ [fetch_attachment] Saved ${bytes} bytes to ${target}`);
+
+          return {
+            content: [{
+              type: 'text',
+              text: `Saved attachment to ${target}\n` +
+                    `  filename    : ${safeName}\n` +
+                    `  content type: ${contentType}\n` +
+                    `  size        : ${bytes.toLocaleString()} bytes\n` +
+                    `  sha256      : ${sha256}`
+            }],
+            structuredContent: output
+          };
+
+        } catch (error) {
+          logger.error(`❌ Attachment download failed for ${url}:`, error);
+          const errorMessage = error instanceof Error ? error.message : 'Unknown download error';
+
+          return {
+            content: [{
+              type: 'text',
+              text: `Failed to download attachment: ${errorMessage}`
             }],
             isError: true
           };

--- a/packages/notes/src/mcp-server.ts
+++ b/packages/notes/src/mcp-server.ts
@@ -379,13 +379,17 @@ class SapNoteMcpServer {
         logger.info(`📎 [fetch_attachment] Downloading ${url}`);
 
         try {
-          const { body, contentType, bytes } = await this.withAuthRetry(token =>
+          const { body, contentType, bytes, suggestedFilename } = await this.withAuthRetry(token =>
             this.sapNotesClient.fetchAttachment(url, token)
           );
 
-          // Never let a caller-supplied name escape the target directory.
-          const fallback = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'attachment');
-          const safeName = basename(filename?.trim() || fallback).replace(/[/\\]/g, '') || 'attachment';
+          // Name precedence: caller > server Content-Disposition > URL path.
+          // The URL path is frequently a generic endpoint name (for example
+          // "attachment.htm"), so preferring it would save a PDF as .htm.
+          const fromUrl = decodeURIComponent(new URL(url).pathname.split('/').pop() || 'attachment');
+          const chosen = filename?.trim() || suggestedFilename?.trim() || fromUrl;
+          // Never let a supplied name escape the target directory.
+          const safeName = basename(chosen).replace(/[/\\]/g, '') || 'attachment';
 
           const dir = outputDir?.trim() ? resolve(outputDir.trim()) : tmpdir();
           if (!existsSync(dir)) {

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -238,7 +238,7 @@ export class SapNotesApiClient {
   async fetchAttachment(
     attachmentUrl: string,
     token: string
-  ): Promise<{ body: Buffer; contentType: string; bytes: number }> {
+  ): Promise<{ body: Buffer; contentType: string; bytes: number; suggestedFilename?: string }> {
     let parsed: URL;
     try {
       parsed = new URL(attachmentUrl);
@@ -290,7 +290,13 @@ export class SapNotesApiClient {
         );
       }
 
-      return { body, contentType, bytes: body.length };
+      // SAP sends the real filename here; the URL path is often a generic
+      // endpoint name such as "attachment.htm", which would otherwise save a
+      // PDF under a .htm extension.
+      const disposition = response.headers()['content-disposition'];
+      const suggestedFilename = SapNotesApiClient.filenameFromDisposition(disposition);
+
+      return { body, contentType, bytes: body.length, suggestedFilename };
     } finally {
       await response.dispose().catch(() => {});
     }
@@ -305,6 +311,23 @@ export class SapNotesApiClient {
    * origins, which is what actually authenticates the document hosts; session
    * cookies are still supplied so cookie-authenticated hosts keep working.
    */
+  /** Extract a filename from a Content-Disposition header, if it carries one. */
+  private static filenameFromDisposition(disposition?: string): string | undefined {
+    if (!disposition) return undefined;
+
+    // RFC 5987 form takes precedence: filename*=UTF-8''name%20with%20spaces.pdf
+    const extended = /filename\*\s*=\s*(?:UTF-8|utf-8)''([^;]+)/i.exec(disposition);
+    if (extended?.[1]) {
+      try {
+        const decoded = decodeURIComponent(extended[1].trim());
+        if (decoded) return decoded;
+      } catch { /* fall through to the plain form */ }
+    }
+
+    const plain = /filename\s*=\s*"?([^";]+)"?/i.exec(disposition);
+    return plain?.[1]?.trim() || undefined;
+  }
+
   private async ensureAttachmentRequestContext(token: string): Promise<APIRequestContext> {
     if (this.attachmentRequestContext) return this.attachmentRequestContext;
 

--- a/packages/notes/src/sap-notes-api.ts
+++ b/packages/notes/src/sap-notes-api.ts
@@ -147,6 +147,7 @@ export class SapNotesApiClient {
   // native fetch, it can initialize directly from Playwright storage state and receives
   // backend JSON without retaining a browser process.
   private backendRequestContext: APIRequestContext | null = null;
+  private attachmentRequestContext: APIRequestContext | null = null;
   private backendRequestContextPromise: Promise<APIRequestContext> | null = null;
 
   constructor(config: ServerConfig) {
@@ -206,6 +207,142 @@ export class SapNotesApiClient {
     } finally {
       this.backendRequestContextPromise = null;
     }
+  }
+
+  /**
+   * Hosts permitted for attachment download. SAP serves Note attachments from
+   * its document hosts; anything else is rejected so that a caller cannot use
+   * this method as a generic fetcher against arbitrary URLs.
+   */
+  private static readonly ATTACHMENT_HOSTS = new Set([
+    'documents.support.sap.com',
+    'userapps.support.sap.com',
+    'launchpad.support.sap.com',
+    'support.sap.com',
+    'me.sap.com'
+  ]);
+
+  private static readonly MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
+
+  /**
+   * Download a Note attachment.
+   *
+   * Attachment URLs come from SapNoteDetail.attachments — they are opaque and
+   * must not be constructed by hand.
+   *
+   * Note that an unauthenticated request to these URLs answers 200 with a small
+   * HTML "Please wait ..." login bootstrap rather than an error status, so the
+   * response is validated by content type as well as status; otherwise the stub
+   * would be written to disk under the attachment's filename.
+   */
+  async fetchAttachment(
+    attachmentUrl: string,
+    token: string
+  ): Promise<{ body: Buffer; contentType: string; bytes: number }> {
+    let parsed: URL;
+    try {
+      parsed = new URL(attachmentUrl);
+    } catch {
+      throw new Error(`Invalid attachment URL: ${attachmentUrl}`);
+    }
+
+    if (parsed.protocol !== 'https:') {
+      throw new Error(`Attachment URL must use https: ${parsed.protocol}//...`);
+    }
+    if (!SapNotesApiClient.ATTACHMENT_HOSTS.has(parsed.hostname)) {
+      throw new Error(
+        `Refusing to download from host "${parsed.hostname}". ` +
+        `Allowed hosts: ${[...SapNotesApiClient.ATTACHMENT_HOSTS].join(', ')}`
+      );
+    }
+
+    const context = await this.ensureAttachmentRequestContext(token);
+    const response = await context.get(parsed.toString(), { failOnStatusCode: false });
+
+    try {
+      const status = response.status();
+      const contentType = response.headers()['content-type'] ?? 'application/octet-stream';
+      const body = await response.body();
+
+      // The login bootstrap is small and HTML; check it before trusting the 200.
+      if (contentType.toLowerCase().includes('text/html')) {
+        const preview = body.subarray(0, 5000).toString('utf8');
+        if (isAuthenticationBootstrapResponse(status, contentType, preview)) {
+          await this.invalidateAttachmentRequestContext();
+          throw new Error(
+            `SESSION_EXPIRED: SAP returned a login page instead of the attachment (${attachmentUrl})`
+          );
+        }
+        throw new Error(
+          `SAP returned HTML rather than a file for ${attachmentUrl} — the attachment may have been removed.`
+        );
+      }
+
+      if (!response.ok()) {
+        throw new Error(`Attachment request failed (${status}) for ${attachmentUrl}`);
+      }
+      if (body.length === 0) {
+        throw new Error(`SAP returned an empty body for ${attachmentUrl}`);
+      }
+      if (body.length > SapNotesApiClient.MAX_ATTACHMENT_BYTES) {
+        throw new Error(
+          `Attachment is ${body.length} bytes, above the ${SapNotesApiClient.MAX_ATTACHMENT_BYTES}-byte limit.`
+        );
+      }
+
+      return { body, contentType, bytes: body.length };
+    } finally {
+      await response.dispose().catch(() => {});
+    }
+  }
+
+  /**
+   * Request context for attachment downloads.
+   *
+   * Attachments are served from support.sap.com hosts, not me.sap.com, so the
+   * me.sap.com-scoped storage state used for backend JSON is not sufficient on
+   * its own. Where a client certificate is configured it is presented for those
+   * origins, which is what actually authenticates the document hosts; session
+   * cookies are still supplied so cookie-authenticated hosts keep working.
+   */
+  private async ensureAttachmentRequestContext(token: string): Promise<APIRequestContext> {
+    if (this.attachmentRequestContext) return this.attachmentRequestContext;
+
+    const options: Parameters<typeof request.newContext>[0] = {
+      ignoreHTTPSErrors: true,
+      timeout: 60000
+    };
+
+    const storageState = await this.loadBackendStorageState(token).catch(() => null);
+    if (storageState) options.storageState = storageState;
+
+    const pfxPath = this.config.pfxPath;
+    if (pfxPath) {
+      try {
+        const { readFileSync, existsSync } = await import('fs');
+        if (existsSync(pfxPath)) {
+          const pfx = readFileSync(pfxPath);
+          options.clientCertificates = [...SapNotesApiClient.ATTACHMENT_HOSTS].map(host => ({
+            origin: `https://${host}`,
+            pfx,
+            passphrase: this.config.pfxPassphrase
+          }));
+        } else {
+          logger.debug(`Attachment client certificate not found at ${pfxPath}`);
+        }
+      } catch (e) {
+        logger.debug(`Attachment client certificate not applied: ${e}`);
+      }
+    }
+
+    this.attachmentRequestContext = await request.newContext(options);
+    return this.attachmentRequestContext;
+  }
+
+  private async invalidateAttachmentRequestContext(): Promise<void> {
+    const context = this.attachmentRequestContext;
+    this.attachmentRequestContext = null;
+    if (context) await context.dispose().catch(() => {});
   }
 
   private async invalidateBackendRequestContext(): Promise<void> {

--- a/packages/notes/src/schemas/sap-notes.ts
+++ b/packages/notes/src/schemas/sap-notes.ts
@@ -314,6 +314,57 @@ USE AFTER search() returns relevant note IDs. Fetch only the top 2-3 results, no
 
 PARAMETER: id — alphanumeric Note ID only (e.g. "2744792"). Strip any "Note" or "SAP Note" prefix.`;
 
+// ─── FETCH ATTACHMENT ──────────────────────────────────────────────────────
+
+/**
+ * Input schema for the "fetch_attachment" tool
+ */
+export const NoteAttachmentInputSchema = {
+  url: z
+    .string()
+    .url()
+    .describe(
+      `Attachment URL exactly as returned in the "attachments" array of fetch(). Must be an SAP document host (e.g. https://documents.support.sap.com/customerkba/...). Do not construct or guess these URLs — take them from fetch() output.`
+    ),
+
+  outputDir: z
+    .string()
+    .optional()
+    .describe(
+      `Directory to write the file into. Defaults to the OS temp directory. The directory must already exist.`
+    ),
+
+  filename: z
+    .string()
+    .optional()
+    .describe(
+      `Filename to save as. Defaults to the attachment's filename from the note, or a name derived from the URL. Path separators are stripped.`
+    )
+};
+
+/**
+ * Output schema for the "fetch_attachment" tool
+ */
+export const NoteAttachmentOutputSchema = {
+  path: z.string().describe('Absolute path of the saved file.'),
+
+  filename: z.string().describe('Filename the attachment was saved as.'),
+
+  contentType: z.string().describe('Content-Type reported by SAP (e.g. "image/png", "application/pdf").'),
+
+  bytes: z.number().int().nonnegative().describe('Size of the saved file in bytes.'),
+
+  sha256: z.string().describe('SHA-256 of the saved bytes, for integrity checking and de-duplication.')
+};
+
+export const SAP_NOTE_ATTACHMENT_DESCRIPTION = `Download a file attached to an SAP Note and save it to disk.
+
+USE AFTER fetch() returns an "attachments" array — pass one of those URLs verbatim. Attachments are the screenshots, PDFs, spreadsheets and archives referenced by a Note's text; the Note body often points at them with placeholders such as [image.png].
+
+Returns the saved path, content type, byte size and SHA-256. Only SAP document hosts are accepted.
+
+NOTE: an unauthenticated or expired session returns HTTP 200 with a small HTML login stub rather than an error. This tool detects that and fails instead of silently saving the stub — so a successful result means real file bytes.`;
+
 // ─── TYPE EXPORTS ──────────────────────────────────────────────────────────
 
 export type NoteSearchInput = z.infer<z.ZodObject<typeof NoteSearchInputSchema>>;
@@ -321,3 +372,5 @@ export type NoteSearchOutput = z.infer<z.ZodObject<typeof NoteSearchOutputSchema
 export type NoteSearchResult = z.infer<z.ZodObject<typeof NoteSearchResultSchema>>;
 export type NoteGetInput = z.infer<z.ZodObject<typeof NoteGetInputSchema>>;
 export type NoteGetOutput = z.infer<z.ZodObject<typeof NoteGetOutputSchema>>;
+export type NoteAttachmentInput = z.infer<z.ZodObject<typeof NoteAttachmentInputSchema>>;
+export type NoteAttachmentOutput = z.infer<z.ZodObject<typeof NoteAttachmentOutputSchema>>;


### PR DESCRIPTION
## What

Adds a **`fetch_attachment`** tool: `fetch()` has surfaced an `attachments` array (filename + url) since the Detail enrichment work, but there was no way to get the bytes. This downloads one and writes it to disk, returning `path`, `contentType`, `bytes` and `sha256`.

## Two things only testing revealed

I built this against a single note and it was wrong in two ways. Both were caught by running it against 10 real notes, and both changed the implementation.

**1. Attachments come from more than one host.** My first allowlist had only `documents.support.sap.com`. In a sample of 10 notes with attachments, **five served from `userapps.support.sap.com`** instead. Both are now allowed.

**2. Attachment hosts don't accept the backend session.** The me.sap.com-scoped `storageState` used by `fetchBackendJson` does **not** authenticate `documents.support.sap.com` — on the first run every download failed `SESSION_EXPIRED`. Attachment downloads now use their own request context that presents the configured **client certificate** for the attachment origins, while still passing session cookies so cookie-authenticated hosts keep working.

## A trap worth knowing about

An unauthenticated request to an attachment URL returns **HTTP 200 with a ~1.8 KB HTML login stub**, not an error:

```
document.write("Please wait ..."); Note: Your browser does not support JavaScript or it is turned off.
```

A downloader checking only the status code would write that stub to disk under the attachment's own filename (`Pasted image.png`) and report success. The tool checks the content type and fails instead — so a successful result means real bytes.

## Safety

Downloads are restricted to an allowlist of SAP hosts so the tool can't be used as a general-purpose fetcher; non-`https` and malformed URLs are rejected; there's a 100 MB cap; and the output filename is `basename`'d so a caller-supplied name can't escape the target directory.

## Test evidence

`scripts/test-attachments.mjs` discovers notes that actually have attachments (rather than assuming a fixed list), throttles to avoid the Detail endpoint's 429, downloads one attachment from each, and asserts the three URL guards.

**10/10 notes, 13/13 checks, 0 failures:**

| Note | Bytes | Content-Type | Magic |
|---|---|---|---|
| 3137004 | 9,579 | image/png | PNG |
| 2388483 | 121,856 | application/vnd.ms-excel | — |
| 2191612 | 79,691 | application/pdf | PDF |
| 1872170 | 942,962 | application/pdf | PDF |
| 1969700 | 1,684,928 | application/x-zip-compressed | ZIP |
| 1438410 | 508,395 | application/x-zip-compressed | ZIP |
| 2187425 | 878,422 | application/pdf | PDF |
| 2543372 | 68,422 | image/png | PNG |
| 2190119 | 98,805 | application/pdf | PDF |
| 1770585 | 632,832 | application/x-tika-msoffice | — |

Hosts seen: `documents.support.sap.com`, `userapps.support.sap.com`.

Guard checks: non-SAP host rejected ✓ · non-https rejected ✓ · malformed URL rejected ✓

## Disclosure

- I could **not** run `vitest` locally — it fails before reaching any test with a rolldown native-binding error on Node 22.11 / macOS arm64, unrelated to this change. The verification above is the live script; please run the suite in CI.
- The test script needs credentials, so it is a manual tool rather than part of the automated suite.
- Unrelated pre-existing warning seen during the run: `Failed to cache session cookies {"code":"ERR_INVALID_ARG_TYPE"}` / `Protocol error (Storage.setCookies): Invalid cookie fields`. Not touched here, but happy to look at it separately if useful.
