### PR TITLE
fix: enforce IAS login origin boundaries

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -87,6 +87,7 @@ async function withAuthRetry<T>(fn: (cookieHeader: string) => Promise<T>): Promi
 - **Shared SSO** — after login the Playwright storage state is written to `ssoStorageStateFile`; other SAP MCP servers seed their browser context from it, so a single SAP login is reused across services. With `sharedSsoTokenFastPath: true` a valid storage-state file is reused **without launching a browser**.
 - **`validateSession` gate** — when provided, it runs on both cached reuse and fresh login; a rejected session is evicted and re-minted once.
 - **Cookie scoping** — `cookieScope` decides which cookies form the header: `{ type: 'url', url }` (origin-scoped), `{ type: 'domain', includes, fallbackToAll? }`, or `{ type: 'all' }`.
+- **Credential-origin guard** — password login fills credentials only on SAP's public identity origin or the configured standard customer-IAS tenant, and refuses to forward the password when federation changes the origin.
 
 ## API
 
@@ -155,6 +156,19 @@ const config = loadAuthConfigFromEnv({
 | `PLAYWRIGHT_BROWSER_TYPE` | `chromium` (default) \| `firefox` \| `webkit` |
 
 When loading configuration from a `.env` file, quote any value containing `#`; dotenv otherwise treats `#` and everything after it as a comment. For example, use `SAP_PASSWORD="My#Pass"`. The same applies to `PFX_PASSPHRASE`.
+
+### Customer IAS and corporate identity providers
+
+Direct password login supports the standard SAP Cloud Identity Services tenant domains
+`*.accounts.ondemand.com`, `*.accounts.cloud.sap`, and `*.accounts.sapcloud.cn`. The authenticator waits
+for the JavaScript redirect used by an unauthenticated tenant `/admin` entry page before detecting the
+credential form.
+
+If conditional authentication delegates the login to a corporate identity provider, the password flow
+fails closed before filling `SAP_PASSWORD` on the new origin. Corporate federation can require different
+credentials, MFA, passkeys, or organization-specific policies and must be completed through a separate
+interactive login flow. The authenticator never assumes that `SAP_PASSWORD` is valid for the delegated
+identity provider.
 
 ### Also exported
 

--- a/packages/auth/src/ias-login.ts
+++ b/packages/auth/src/ias-login.ts
@@ -63,15 +63,94 @@ const SUBMIT_SELECTORS = [
   'button[id*="submit" i]'
 ];
 
+const SAP_PUBLIC_IDENTITY_ORIGIN = 'https://accounts.sap.com';
+const STANDARD_CUSTOMER_IAS_SUFFIXES = [
+  '.accounts.ondemand.com',
+  '.accounts.cloud.sap',
+  '.accounts.sapcloud.cn'
+];
+const CUSTOMER_IAS_AUTH_PATH_PREFIXES = ['/saml2/', '/oauth2/', '/ui/', '/ids/'];
+const IAS_BOOTSTRAP_TIMEOUT_MS = 10000;
+
+function parseUrl(value: string): URL | undefined {
+  try {
+    return new URL(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function isStandardCustomerIasHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return STANDARD_CUSTOMER_IAS_SUFFIXES.some(suffix => normalized.endsWith(suffix));
+}
+
+function isStandardCustomerIasAuthUrl(value: string): boolean {
+  const parsed = parseUrl(value);
+  if (!parsed || !isStandardCustomerIasHostname(parsed.hostname)) return false;
+  const path = parsed.pathname.toLowerCase();
+  return CUSTOMER_IAS_AUTH_PATH_PREFIXES.some(prefix => path.startsWith(prefix));
+}
+
+function isCustomerIasBootstrapPage(url: string, title: string): boolean {
+  const parsed = parseUrl(url);
+  if (!parsed || !isStandardCustomerIasHostname(parsed.hostname)) return false;
+  return parsed.pathname.toLowerCase().startsWith('/admin') &&
+    title.toLowerCase().includes('administration console');
+}
+
+function allowedCredentialOrigins(config: AuthConfig): Set<string> {
+  const origins = new Set([SAP_PUBLIC_IDENTITY_ORIGIN]);
+  const configuredLogin = config.sapLoginUrl ? parseUrl(config.sapLoginUrl) : undefined;
+  if (
+    configuredLogin?.protocol === 'https:' &&
+    isStandardCustomerIasHostname(configuredLogin.hostname)
+  ) {
+    origins.add(configuredLogin.origin);
+  }
+  return origins;
+}
+
+// Login selectors intentionally support several IAS page variants. Re-check the
+// top-level origin immediately before every fill so a redirect cannot rebind a
+// generic username/password selector to a delegated or lookalike identity site.
+function requireCredentialOrigin(
+  page: Page,
+  config: AuthConfig,
+  field: 'username' | 'password',
+  expectedOrigin?: string
+): string {
+  const parsed = parseUrl(page.url());
+  const origin = parsed?.origin;
+  const allowed = allowedCredentialOrigins(config);
+
+  if (!origin || !allowed.has(origin)) {
+    throw new AuthenticationError(
+      `Refusing to fill SAP ${field} on untrusted origin ${origin ?? 'unknown'}. ` +
+      `Allowed credential origins: ${[...allowed].join(', ')}. ` +
+      'The login may have been delegated to a corporate identity provider; complete that flow with a separate interactive login.'
+    );
+  }
+  if (expectedOrigin && origin !== expectedOrigin) {
+    throw new AuthenticationError(
+      `Refusing to fill SAP ${field} after the credential origin changed from ${expectedOrigin} to ${origin}. ` +
+      'The login may have been delegated to a corporate identity provider; complete that flow with a separate interactive login.'
+    );
+  }
+  return origin;
+}
+
 export function isOnAuthPage(url: string, title: string): boolean {
   const combined = `${url} ${title}`.toLowerCase();
   return (
+    isStandardCustomerIasAuthUrl(url) ||
     combined.includes('authentication') ||
     combined.includes('accounts.sap.com') ||
     combined.includes('login') ||
     combined.includes('oauth') ||
     combined.includes('saml') ||
     combined.includes('sign in') ||
+    combined.includes('log on') ||
     combined.includes('two-factor') ||
     combined.includes('verify') ||
     combined.includes('passcode')
@@ -81,6 +160,7 @@ export function isOnAuthPage(url: string, title: string): boolean {
 export function isAuthUrl(url: string): boolean {
   const value = url.toLowerCase();
   return (
+    isStandardCustomerIasAuthUrl(url) ||
     value.includes('authentication') ||
     value.includes('accounts.sap.com') ||
     value.includes('login') ||
@@ -106,6 +186,24 @@ async function openAuthPage(page: Page, url: string, label: string, logger: Logg
   await page.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {
     logger.warn(`${label} DOMContentLoaded wait timed out; continuing with login detection`);
   });
+
+  const committedUrl = page.url();
+  const committedTitle = await page.title();
+  if (isCustomerIasBootstrapPage(committedUrl, committedTitle)) {
+    logger.warn(`${label} reached the SAP Cloud Identity Services bootstrap page; waiting for its authentication redirect`);
+    const redirected = await page.waitForURL(
+      next => next.toString() !== committedUrl,
+      { timeout: IAS_BOOTSTRAP_TIMEOUT_MS, waitUntil: 'commit' }
+    ).then(() => true).catch(() => false);
+
+    if (redirected) {
+      await page.waitForLoadState('domcontentloaded', { timeout: 15000 }).catch(() => {
+        logger.warn(`${label} authentication redirect did not finish loading; continuing with login detection`);
+      });
+    } else {
+      logger.warn(`${label} SAP Cloud Identity Services bootstrap did not redirect within ${IAS_BOOTSTRAP_TIMEOUT_MS / 1000}s`);
+    }
+  }
 }
 
 async function tryFillFirstVisible(
@@ -114,11 +212,13 @@ async function tryFillFirstVisible(
   value: string,
   label: string,
   timeout: number,
-  logger: Logger
+  logger: Logger,
+  beforeFill?: () => void
 ): Promise<boolean> {
   for (const selector of selectors) {
     const field = await page.waitForSelector(selector, { timeout, state: 'visible' }).catch(() => null);
     if (field) {
+      beforeFill?.();
       await field.click({ clickCount: 3 });
       await field.fill(value);
       logger.warn(`Filled ${label} field using selector ${selector}`);
@@ -133,9 +233,10 @@ async function fillFirstVisible(
   selectors: string[],
   value: string,
   label: string,
-  logger: Logger
+  logger: Logger,
+  beforeFill?: () => void
 ): Promise<void> {
-  const filled = await tryFillFirstVisible(page, selectors, value, label, 5000, logger);
+  const filled = await tryFillFirstVisible(page, selectors, value, label, 5000, logger, beforeFill);
   if (!filled) {
     await page.screenshot({ path: `debug-${label}-not-found.png`, fullPage: true }).catch(() => {});
     throw new AuthenticationError(`Could not find ${label} field on SAP login page`);
@@ -169,13 +270,33 @@ async function completePasswordLoginIfNeeded(
   }
 
   logger.warn(`Authentication page detected: ${pageTitle} at ${currentUrl}`);
-  await fillFirstVisible(page, USERNAME_SELECTORS, config.sapUsername!, 'username', logger);
+  let credentialOrigin = '';
+  await fillFirstVisible(page, USERNAME_SELECTORS, config.sapUsername!, 'username', logger, () => {
+    credentialOrigin = requireCredentialOrigin(page, config, 'username');
+  });
 
-  let passwordFilled = await tryFillFirstVisible(page, PASSWORD_SELECTORS, config.sapPassword!, 'password', 500, logger);
+  const guardPasswordFill = () => requireCredentialOrigin(page, config, 'password', credentialOrigin);
+  let passwordFilled = await tryFillFirstVisible(
+    page,
+    PASSWORD_SELECTORS,
+    config.sapPassword!,
+    'password',
+    500,
+    logger,
+    guardPasswordFill
+  );
   if (!passwordFilled) {
     logger.warn('Password field not visible yet; submitting username step');
     await clickFirstVisible(page, CONTINUE_SELECTORS, 'continue', logger);
-    passwordFilled = await tryFillFirstVisible(page, PASSWORD_SELECTORS, config.sapPassword!, 'password', 15000, logger);
+    passwordFilled = await tryFillFirstVisible(
+      page,
+      PASSWORD_SELECTORS,
+      config.sapPassword!,
+      'password',
+      15000,
+      logger,
+      guardPasswordFill
+    );
     if (!passwordFilled) {
       throw new AuthenticationError('Could not find password field after username submission');
     }

--- a/packages/auth/test/ias-login.test.ts
+++ b/packages/auth/test/ias-login.test.ts
@@ -1,0 +1,197 @@
+import type { Page } from 'playwright';
+import { describe, expect, it } from 'vitest';
+import { isAuthUrl, isOnAuthPage, performPasswordLogin } from '../src/ias-login.js';
+import type { AuthConfig, Logger, ServiceProfile } from '../src/types.js';
+
+const logger: Logger = {
+  warn() {},
+  error() {},
+  info() {},
+  debug() {}
+};
+
+function config(sapLoginUrl: string): AuthConfig {
+  return {
+    authMethod: 'password',
+    sapUsername: 'dummy.user@example.invalid',
+    sapPassword: 'DUMMY_PASSWORD',
+    sapLoginUrl,
+    mfaTimeout: 1_000,
+    maxSessionAgeH: 1,
+    headful: false,
+    tokenCacheFile: '/tmp/not-used.json',
+    logger
+  };
+}
+
+const profile: ServiceProfile = {
+  serviceName: 'IAS login test',
+  cookieScope: { type: 'all' }
+};
+
+type Scenario = 'public-same-origin' | 'customer-bootstrap' | 'federated-cross-origin' | 'lookalike-origin';
+type Stage = 'initial' | 'bootstrap' | 'username' | 'password' | 'complete';
+
+class FakeLoginPage {
+  currentUrl = 'about:blank';
+  currentTitle = '';
+  stage: Stage = 'initial';
+  readonly filled: Array<{ label: 'username' | 'password'; origin: string; value: string }> = [];
+
+  constructor(private readonly scenario: Scenario) {}
+
+  async goto(url: string): Promise<null> {
+    if (this.scenario === 'customer-bootstrap') {
+      this.currentUrl = url;
+      this.stage = 'bootstrap';
+      this.currentTitle = 'Administration Console for Cloud Identity Services';
+    } else {
+      this.currentUrl = this.scenario === 'public-same-origin'
+        ? 'https://accounts.sap.com/saml2/idp/sso'
+        : this.scenario === 'lookalike-origin'
+          ? 'https://accounts.sap.com.evil.example/login'
+          : url;
+      this.stage = 'username';
+      this.currentTitle = 'Sign In';
+    }
+    return null;
+  }
+
+  async waitForLoadState(): Promise<void> {}
+
+  async waitForURL(predicate: (url: URL) => boolean): Promise<void> {
+    if (this.stage === 'bootstrap') {
+      this.stage = 'username';
+      this.currentUrl = 'https://tenant.accounts.ondemand.com/saml2/idp/sso?sp=example';
+      this.currentTitle = 'Administration Console: Sign In';
+    }
+    if (!predicate(new URL(this.currentUrl))) {
+      throw new Error(`URL predicate rejected ${this.currentUrl}`);
+    }
+  }
+
+  async waitForSelector(selector: string): Promise<FakeElement | null> {
+    if (this.stage === 'username' && selector === '#j_username') {
+      return new FakeElement(this, 'username');
+    }
+    if (this.stage === 'password' && selector === '#j_password') {
+      return new FakeElement(this, 'password');
+    }
+    if ((this.stage === 'username' || this.stage === 'password') && selector === '#logOnFormSubmit') {
+      return new FakeElement(this, 'button');
+    }
+    return null;
+  }
+
+  async waitForTimeout(): Promise<void> {}
+  async screenshot(): Promise<Buffer> { return Buffer.alloc(0); }
+  url(): string { return this.currentUrl; }
+  async title(): Promise<string> { return this.currentTitle; }
+
+  advance(): void {
+    if (this.stage === 'username') {
+      this.stage = 'password';
+      if (this.scenario === 'federated-cross-origin') {
+        this.currentUrl = 'https://login.corporate-idp.example/password';
+        this.currentTitle = 'Corporate Identity Provider';
+      } else if (this.scenario === 'public-same-origin') {
+        this.currentUrl = 'https://accounts.sap.com/ui/password';
+        this.currentTitle = 'Sign In';
+      } else {
+        this.currentUrl = 'https://tenant.accounts.ondemand.com/ui/password';
+        this.currentTitle = 'Log On';
+      }
+      return;
+    }
+
+    this.stage = 'complete';
+    this.currentUrl = 'https://service.example/complete';
+    this.currentTitle = 'Target Application';
+  }
+}
+
+class FakeElement {
+  constructor(
+    private readonly page: FakeLoginPage,
+    private readonly kind: 'username' | 'password' | 'button'
+  ) {}
+
+  async click(): Promise<void> {
+    if (this.kind === 'button') this.page.advance();
+  }
+
+  async fill(value: string): Promise<void> {
+    if (this.kind === 'button') throw new Error('Cannot fill a button');
+    this.page.filled.push({
+      label: this.kind,
+      origin: new URL(this.page.currentUrl).origin,
+      value
+    });
+  }
+}
+
+describe('SAP IAS password login boundaries', () => {
+  it('preserves the supported accounts.sap.com two-step password flow', async () => {
+    const page = new FakeLoginPage('public-same-origin');
+
+    await performPasswordLogin(
+      page as unknown as Page,
+      config('https://me.sap.com/home'),
+      profile,
+      logger
+    );
+
+    expect(page.filled).toEqual([
+      { label: 'username', origin: 'https://accounts.sap.com', value: 'dummy.user@example.invalid' },
+      { label: 'password', origin: 'https://accounts.sap.com', value: 'DUMMY_PASSWORD' }
+    ]);
+  });
+
+  it('refuses to forward the configured SAP password to a federated corporate IdP', async () => {
+    const page = new FakeLoginPage('federated-cross-origin');
+
+    await expect(performPasswordLogin(
+      page as unknown as Page,
+      config('https://accounts.sap.com/saml2/idp/sso'),
+      profile,
+      logger
+    )).rejects.toThrow(/refusing to fill.*password.*origin/i);
+
+    expect(page.filled.filter(entry => entry.label === 'password')).toEqual([]);
+  });
+
+  it('rejects a lookalike hostname before filling even the username', async () => {
+    const page = new FakeLoginPage('lookalike-origin');
+
+    await expect(performPasswordLogin(
+      page as unknown as Page,
+      config('https://accounts.sap.com/saml2/idp/sso'),
+      profile,
+      logger
+    )).rejects.toThrow(/untrusted origin https:\/\/accounts\.sap\.com\.evil\.example/i);
+
+    expect(page.filled).toEqual([]);
+  });
+
+  it('waits through the customer-IAS admin bootstrap before looking for credentials', async () => {
+    const page = new FakeLoginPage('customer-bootstrap');
+
+    await performPasswordLogin(
+      page as unknown as Page,
+      config('https://tenant.accounts.ondemand.com/admin/'),
+      profile,
+      logger
+    );
+
+    expect(page.filled).toEqual([
+      { label: 'username', origin: 'https://tenant.accounts.ondemand.com', value: 'dummy.user@example.invalid' },
+      { label: 'password', origin: 'https://tenant.accounts.ondemand.com', value: 'DUMMY_PASSWORD' }
+    ]);
+  });
+
+  it('recognizes standard customer-IAS login URLs and the Log On title', () => {
+    const url = 'https://tenant.accounts.cloud.sap/ui/public?spId=example';
+    expect(isOnAuthPage(url, 'Log On')).toBe(true);
+    expect(isAuthUrl(url)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Goal

Harden the shared SAP IAS password-login flow against credential disclosure after corporate identity-provider redirects, while making customer IAS `/admin` bootstrap logins settle reliably.

## Root cause

- The login helper used broad username/password selectors without validating the page origin at the moment credentials were filled. If IAS delegated authentication to a corporate IdP, the configured SAP password could be entered into that unrelated origin.
- Customer IAS administration-console URLs initially load a bootstrap document. The login flow inspected that document immediately after `DOMContentLoaded`, before it redirected to the tenant's SAML sign-in page, so authentication-page detection could fail.

## What changed

- Allow automated credential filling only on SAP's public identity origin or the configured standard customer IAS tenant origin.
- Require the password origin to match the origin where the username was entered; delegated corporate IdP redirects now fail closed before filling the password.
- Wait through the recognized customer IAS `/admin` bootstrap redirect before detecting and filling the sign-in form.
- Recognize standard customer IAS authentication paths and `Log On` pages.
- Add regression tests for public SAP IAS, customer IAS bootstrap/direct login, cross-origin federation, and a lookalike origin.
- Document the supported customer IAS and corporate-IdP behavior.

## Validation

- `npm ci`
- `npm run build`
- `npm run typecheck`
- `npm test -w @marianfoo/sap-mcp-auth` (5/5)
- `npm run test:unit -w sap-note-search-mcp` (12/12)
- `npm run pack:check -w @marianfoo/sap-mcp-auth`
- Server initialization smoke tests for API Hub, Roadmap, and Notes
- Browser-level regression reproduction: the corporate IdP password field remains empty and no password is posted
- Live, read-only customer IAS bootstrap check: the initial `/admin` page settles on the tenant SAML sign-in page and is recognized
- `git diff --check`

## Behavior note

Direct login remains supported for `accounts.sap.com` and configured standard customer IAS tenant domains. Corporate-IdP federation intentionally stops before entering the SAP password and needs a separate interactive/provider-specific flow.
